### PR TITLE
DEVOPS-442: Disable concurrency inside reusable-python-* workflows

### DIFF
--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -19,10 +19,6 @@ on:
         type: number
         default: 1
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   pytest:
     name: pytest

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -22,10 +22,6 @@ on:
         description: 'Codecov token'
         required: false
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   pytest:
     name: pytest (Windows)

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -13,10 +13,6 @@ on:
         type: string
         default: '3.10'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 env:
   source_dir: ${{inputs.app_name}}
 


### PR DESCRIPTION
**DEVOPS-442 - Choice python version in Static Analysis shared workflow**
