### PR TITLE
DEVOPS-459: 

### DIFF
--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -11,13 +11,6 @@ inputs:
     type: string
     default: 'bash'
 
-env:
-  PYTHONUTF8: 1
-  CONDA_CHANNEL_PRIORITY: strict
-  PIP_NO_DEPS: 1 # all dependencies are installed from conda
-  INPUT_PYTHON_VER: ${{ inputs.python_ver }}
-  CONDA_LOCK_ENV_FILE: environments/py-${INPUT_PYTHON_VER}-win-64-dev.conda.lock.yml
-
 runs:
   using: "composite"
   steps:
@@ -28,3 +21,9 @@ runs:
         environment-name: test_env
         init-shell: ${{ inputs.shell_type }}
         cache-downloads: true
+      env:
+  PYTHONUTF8: 1
+  CONDA_CHANNEL_PRIORITY: strict
+  PIP_NO_DEPS: 1 # all dependencies are installed from conda
+  INPUT_PYTHON_VER: ${{ inputs.python_ver }}
+  CONDA_LOCK_ENV_FILE: environments/py-${INPUT_PYTHON_VER}-win-64-dev.conda.lock.yml

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Shell type to use'
     required: false
     type: string
-    default: 'bash -l {0}'
+    default: 'none'
 
 runs:
   using: "composite"

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -30,4 +30,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ env.os_conda }}-64-dev.conda.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ inputs.python_ver }}-${{ env.os_conda }}-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -25,5 +25,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        INPUT_PYTHON_VER: ${{ inputs.python_ver }}
         CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver}}-win-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Echo
       run: |
         echo $RUNNER_OS
-        os_conda=$( [[ $RUNNER_OS == "linux" ]] && echo "linux" || echo "win")
+        os_conda=$( [[ $RUNNER_OS == "Linux" ]] && echo "linux" || echo "win")
         echo $os_conda
         echo "os_conda=$os_conda" >> $GITHUB_ENV
         echo $GITHUB_WORKSPACE
@@ -35,4 +35,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver }}-linux-64-dev.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver }}-linux-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -16,9 +16,8 @@ runs:
   steps:
     - name: Echo
       run: |
-        echo $RUNNER_OS
-        os=$( [[ "$RUNNER_OS" == "bash" ]] && "lin" || echo "lin")
-        os="lin"
+        os_conda=$( [[ "$RUNNER_OS" == "linux" ]] && "lin" || echo "lin")
+        echo "os_conda=$os_conda" >> $GITHUB_ENV
       shell: bash
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
@@ -31,4 +30,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/py-${{ env.os }}-64-dev.conda.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/py-${{ env.os_conda }}-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -5,11 +5,6 @@ inputs:
     description: 'Python version to use'
     required: true
     type: string
-  shell_type:
-    description: 'Shell type to use'
-    required: false
-    type: string
-    default: 'bash'
 
 runs:
   using: "composite"
@@ -25,7 +20,7 @@ runs:
       with:
         environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
         environment-name: test_env
-        init-shell: '${{ inputs.shell_type }}'
+        init-shell: bash
         cache-downloads: true
       env:
         PYTHONUTF8: 1

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -14,11 +14,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/checkout@v4
     - name: Echo
       run: |
-        os_conda=$( [[ "$RUNNER_OS" == "linux" ]] && echo "linux" || echo "win")
+        os_conda=$( [[ $RUNNER_OS == "linux" ]] && echo "linux" || echo "win")
         echo $os_conda
         echo "os_conda=$os_conda" >> $GITHUB_ENV
+        echo $GITHUB_WORKSPACE
+        ls .
       shell: bash
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
@@ -26,7 +29,7 @@ runs:
         environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
         environment-name: test_env
         init-shell: '${{ inputs.shell_type }}'
-        cache-downloads: false
+        cache-downloads: true
       env:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -29,4 +29,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/py-${{os}}-64-dev.conda.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/py-${{ env.os }}-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Shell type to use'
     required: false
     type: string
-    default: 'bash'
+    default: 'bash -l {0}'
 
 runs:
   using: "composite"
@@ -19,7 +19,7 @@ runs:
       with:
         environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
         environment-name: test_env
-        init-shell: ${{ inputs.shell_type }}
+        init-shell: '${{ inputs.shell_type }}'
         cache-downloads: true
       env:
         PYTHONUTF8: 1

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -17,11 +17,12 @@ runs:
     - uses: actions/checkout@v4
     - name: Echo
       run: |
+        echo $RUNNER_OS
         os_conda=$( [[ $RUNNER_OS == "linux" ]] && echo "linux" || echo "win")
         echo $os_conda
         echo "os_conda=$os_conda" >> $GITHUB_ENV
         echo $GITHUB_WORKSPACE
-        ls .
+        ls environments
       shell: bash
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
@@ -34,4 +35,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ inputs.python_ver }}-linux-64-dev.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver }}-linux-64-dev.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Echo
       run: |
-        echo "${{ inputs.shell_type }}"
+        os=$( [[ "$RUNNER_OS" == "bash" ]] && "lin" || echo "lin")
       shell: bash
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
@@ -29,4 +29,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver}}-win-64-dev.conda.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/py-${{os}}-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -1,0 +1,29 @@
+name: Setup conda env
+description: Setup conda environment for Python
+inputs:
+  python_ver:
+    description: 'Python version to use'
+    required: true
+    type: string
+  shell_type:
+    description: 'Shell type to use'
+    required: false
+    type: string
+    default: 'bash'
+
+env:
+  PYTHONUTF8: 1
+  CONDA_CHANNEL_PRIORITY: strict
+  PIP_NO_DEPS: 1 # all dependencies are installed from conda
+  CONDA_LOCK_ENV_FILE: environments/py-${{ inputs.python_ver }}-win-64-dev.conda.lock.yml
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup conda env
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
+        environment-name: test_env
+        init-shell: ${{ inputs.shell_type }}
+        cache-downloads: true

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Shell type to use'
     required: false
     type: string
-    default: 'none'
+    default: 'bash'
 
 runs:
   using: "composite"

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -15,7 +15,8 @@ env:
   PYTHONUTF8: 1
   CONDA_CHANNEL_PRIORITY: strict
   PIP_NO_DEPS: 1 # all dependencies are installed from conda
-  CONDA_LOCK_ENV_FILE: environments/py-${{ inputs.python_ver }}-win-64-dev.conda.lock.yml
+  INPUT_PYTHON_VER: ${{ inputs.python_ver }}
+  CONDA_LOCK_ENV_FILE: environments/py-${INPUT_PYTHON_VER}-win-64-dev.conda.lock.yml
 
 runs:
   using: "composite"

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -22,8 +22,8 @@ runs:
         init-shell: ${{ inputs.shell_type }}
         cache-downloads: true
       env:
-  PYTHONUTF8: 1
-  CONDA_CHANNEL_PRIORITY: strict
-  PIP_NO_DEPS: 1 # all dependencies are installed from conda
-  INPUT_PYTHON_VER: ${{ inputs.python_ver }}
-  CONDA_LOCK_ENV_FILE: environments/py-${INPUT_PYTHON_VER}-win-64-dev.conda.lock.yml
+        PYTHONUTF8: 1
+        CONDA_CHANNEL_PRIORITY: strict
+        PIP_NO_DEPS: 1 # all dependencies are installed from conda
+        INPUT_PYTHON_VER: ${{ inputs.python_ver }}
+        CONDA_LOCK_ENV_FILE: environments/py-${INPUT_PYTHON_VER}-win-64-dev.conda.lock.yml

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -17,6 +17,7 @@ runs:
     - name: Echo
       run: |
         os_conda=$( [[ "$RUNNER_OS" == "linux" ]] && echo "linux" || echo "win")
+        echo $os_conda
         echo "os_conda=$os_conda" >> $GITHUB_ENV
       shell: bash
     - name: Setup conda env
@@ -30,4 +31,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ inputs.python_ver }}-${{ env.os_conda }}-64-dev.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ inputs.python_ver }}-linux-64-dev.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Echo
       run: |
-        os_conda=$( [[ "$RUNNER_OS" == "linux" ]] && "linux" || echo "win")
+        os_conda=$( [[ "$RUNNER_OS" == "linux" ]] && echo "linux" || echo "win")
         echo "os_conda=$os_conda" >> $GITHUB_ENV
       shell: bash
     - name: Setup conda env
@@ -30,4 +30,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ inputs.python_ver }}-${{ env.os_conda }}-64-dev.conda.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ inputs.python_ver }}-${{ env.os_conda }}-64-dev.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Echo
       run: |
-        os_conda=$( [[ "$RUNNER_OS" == "linux" ]] && "lin" || echo "lin")
+        os_conda=$( [[ "$RUNNER_OS" == "linux" ]] && "linux" || echo "win")
         echo "os_conda=$os_conda" >> $GITHUB_ENV
       shell: bash
     - name: Setup conda env
@@ -30,4 +30,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/py-${{ env.os_conda }}-64-dev.conda.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/conda-py-${{ env.os_conda }}-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -16,8 +16,8 @@ runs:
   steps:
     - name: Echo
       run: |
-        echo: ${{ inputs.shell_type }}
-      shell: ${{ inputs.shell_type }}
+        echo "${{ inputs.shell_type }}"
+      shell: bash
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
       with:

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -14,6 +14,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Echo
+      run: |
+        echo: ${{ inputs.shell_type }}
+      shell: ${{ inputs.shell_type }}
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
       with:

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -17,12 +17,8 @@ runs:
     - uses: actions/checkout@v4
     - name: Echo
       run: |
-        echo $RUNNER_OS
         os_conda=$( [[ $RUNNER_OS == "Linux" ]] && echo "linux" || echo "win")
-        echo $os_conda
         echo "os_conda=$os_conda" >> $GITHUB_ENV
-        echo $GITHUB_WORKSPACE
-        ls environments
       shell: bash
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
@@ -35,4 +31,4 @@ runs:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver }}-linux-64-dev.conda.lock.yml'
+        CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver }}-${{ env.os_conda }}-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -16,7 +16,9 @@ runs:
   steps:
     - name: Echo
       run: |
+        echo $RUNNER_OS
         os=$( [[ "$RUNNER_OS" == "bash" ]] && "lin" || echo "lin")
+        os="lin"
       shell: bash
     - name: Setup conda env
       uses: mamba-org/setup-micromamba@v1
@@ -24,7 +26,7 @@ runs:
         environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}
         environment-name: test_env
         init-shell: '${{ inputs.shell_type }}'
-        cache-downloads: true
+        cache-downloads: false
       env:
         PYTHONUTF8: 1
         CONDA_CHANNEL_PRIORITY: strict

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -26,4 +26,4 @@ runs:
         CONDA_CHANNEL_PRIORITY: strict
         PIP_NO_DEPS: 1 # all dependencies are installed from conda
         INPUT_PYTHON_VER: ${{ inputs.python_ver }}
-        CONDA_LOCK_ENV_FILE: environments/py-${INPUT_PYTHON_VER}-win-64-dev.conda.lock.yml
+        CONDA_LOCK_ENV_FILE: 'environments/py-${{ inputs.python_ver}}-win-64-dev.conda.lock.yml'

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
-    - name: Echo
+    - name: Setup CONDA_LOCK_ENV_FILE
       run: |
         os_conda=$( [[ $RUNNER_OS == "Linux" ]] && echo "linux" || echo "win")
         echo "os_conda=$os_conda" >> $GITHUB_ENV

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -29,10 +29,12 @@ runs:
     - name: Get full Python version
       id: full-python-version
       run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
+      shell: ${{ inputs.shell_type }}
     - name: Install poetry
       run: |
         curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+      shell: ${{ inputs.shell_type }}
     - name: Set up cache
       uses: actions/cache@v4
       id: cache
@@ -44,5 +46,7 @@ runs:
     - name: Ensure cache is healthy
       if: steps.cache.outputs.cache-hit == 'true'
       run: timeout 10s poetry run pip --version || rm -rf .venv
+      shell: ${{ inputs.shell_type }}
     - name: Install dependencies
       run: poetry install -vvv
+      shell: ${{ inputs.shell_type }}

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -5,11 +5,6 @@ inputs:
     description: 'Python version to use'
     required: true
     type: string
-  shell_type:
-    description: 'Shell type to use'
-    required: false
-    type: string
-    default: 'bash'
   cache_number:
     description: 'Cache number to reset cache if poetry.lock has not changed'
     required: true

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -26,6 +26,11 @@ runs:
         curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       shell: bash
+    - name: Config poetry
+      run: |
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
+      shell: bash
     - name: Set up cache
       uses: actions/cache@v4
       id: cache

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -19,11 +19,12 @@ inputs:
     required: true
     type: string
 
+env:
+  POETRY_VIRTUALENVS_CREATE: true
+  POETRY_VIRTUALENVS_IN_PROJECT: true
+
 runs:
   using: "composite"
-  env:
-    POETRY_VIRTUALENVS_CREATE: true
-    POETRY_VIRTUALENVS_IN_PROJECT: true
   steps:
     - name: Get full Python version
       id: full-python-version

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Runner OS'
     required: true
     type: string
+  shell:
+    description: 'Shell type to use'
+    required: false
+    type: string
 
 runs:
   using: "composite"

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -21,9 +21,6 @@ inputs:
 
 runs:
   using: "composite"
-  defaults:
-      run:
-        shell: bash
   env:
     POETRY_VIRTUALENVS_CREATE: true
     POETRY_VIRTUALENVS_IN_PROJECT: true
@@ -31,12 +28,12 @@ runs:
     - name: Get full Python version
       id: full-python-version
       run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
-      # shell: ${{ inputs.shell_type }}
+      shell: bash
     - name: Install poetry
       run: |
         curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-      # shell: ${{ inputs.shell_type }}
+      shell: bash
     - name: Set up cache
       uses: actions/cache@v4
       id: cache
@@ -48,7 +45,7 @@ runs:
     - name: Ensure cache is healthy
       if: steps.cache.outputs.cache-hit == 'true'
       run: timeout 10s poetry run pip --version || rm -rf .venv
-      # shell: ${{ inputs.shell_type }}
+      shell: bash
     - name: Install dependencies
       run: poetry install -vvv
-      # shell: ${{ inputs.shell_type }}
+      shell: bash

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -19,10 +19,6 @@ inputs:
     required: true
     type: string
 
-env:
-  POETRY_VIRTUALENVS_CREATE: true
-  POETRY_VIRTUALENVS_IN_PROJECT: true
-
 runs:
   using: "composite"
   steps:

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -13,10 +13,6 @@ inputs:
     description: 'Runner OS'
     required: true
     type: string
-  shell:
-    description: 'Shell type to use'
-    required: false
-    type: string
 
 runs:
   using: "composite"

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -19,22 +19,24 @@ inputs:
     required: true
     type: string
 
-env:
-  POETRY_VIRTUALENVS_CREATE: true
-  POETRY_VIRTUALENVS_IN_PROJECT: true
-
 runs:
   using: "composite"
+  defaults:
+      run:
+        shell: bash
+  env:
+    POETRY_VIRTUALENVS_CREATE: true
+    POETRY_VIRTUALENVS_IN_PROJECT: true
   steps:
     - name: Get full Python version
       id: full-python-version
       run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
-      shell: ${{ inputs.shell_type }}
+      # shell: ${{ inputs.shell_type }}
     - name: Install poetry
       run: |
         curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-      shell: ${{ inputs.shell_type }}
+      # shell: ${{ inputs.shell_type }}
     - name: Set up cache
       uses: actions/cache@v4
       id: cache
@@ -46,7 +48,7 @@ runs:
     - name: Ensure cache is healthy
       if: steps.cache.outputs.cache-hit == 'true'
       run: timeout 10s poetry run pip --version || rm -rf .venv
-      shell: ${{ inputs.shell_type }}
+      # shell: ${{ inputs.shell_type }}
     - name: Install dependencies
       run: poetry install -vvv
-      shell: ${{ inputs.shell_type }}
+      # shell: ${{ inputs.shell_type }}

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -1,0 +1,48 @@
+name: Setup poetry env
+description: Setup poetry environment for Python
+inputs:
+  python_ver:
+    description: 'Python version to use'
+    required: true
+    type: string
+  shell_type:
+    description: 'Shell type to use'
+    required: false
+    type: string
+    default: 'bash'
+  cache_number:
+    description: 'Cache number to reset cache if poetry.lock has not changed'
+    required: true
+    type: number
+  runner_os:
+    description: 'Runner OS'
+    required: true
+    type: string
+
+env:
+  POETRY_VIRTUALENVS_CREATE: true
+  POETRY_VIRTUALENVS_IN_PROJECT: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get full Python version
+      id: full-python-version
+      run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
+    - name: Install poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
+        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+    - name: Set up cache
+      uses: actions/cache@v4
+      id: cache
+      env:
+        CACHE_NUMBER: ${{ inputs.cache_number }}
+      with:
+        path: .venv
+        key: venv-${{ inputs.runner_os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}-{{ inputs.CACHE_NUMBER }}
+    - name: Ensure cache is healthy
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: timeout 10s poetry run pip --version || rm -rf .venv
+    - name: Install dependencies
+      run: poetry install -vvv

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -1,0 +1,42 @@
+name: Pre-commit
+
+on:
+  workflow_call:
+    inputs:
+      app_name:
+        description: 'Name of the app to run pre-commit on'
+        required: true
+        type: string
+
+env:
+  source_dir: ${{inputs.app_name}}
+
+jobs:
+  pre-commit:
+    name: pre-commit
+    if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.draft == false) }}
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    env:
+      SKIP: pylint
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: capture modified files
+        if: ${{ github.event_name == 'pull_request' }}
+        run: >-
+          git fetch --deepen=500 origin ${{github.base_ref}}
+          && echo "FILES_PARAM=$(
+          git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | grep -E "^(${source_dir}|tests)/.*\.py$" | xargs
+          )" >> $GITHUB_ENV
+      - name: Run pre-commit on modified files
+        if: ${{ (github.event_name == 'pull_request') && (env.FILES_PARAM) }}
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --hook-stage push --files ${{ env.FILES_PARAM }}
+      - name: Run pre-commit on all files
+        if: ${{ github.event_name == 'push' }}
+        uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --hook-stage push --all-files

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -54,7 +54,6 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: ${{ inputs.shell_type }}
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -23,11 +23,6 @@ on:
         required: false
         type: number
         default: 1
-      shell_type:
-        description: 'Shell type to use'
-        required: false
-        type: string
-        default: 'bash'
 
 jobs:
   pytest:
@@ -41,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: ${{ inputs.shell_type }}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -63,4 +63,7 @@ jobs:
         run: poetry run pytest --cov --cov-report=xml
       - name: Run Pytest (with conda)
         if : ${{ inputs.package_manager == 'conda' }}
-        run: pytest --cov --cov-report=xml
+        run: |
+          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
+          $(${RUNNER} pytest --cov --cov-report=xml)
+        

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -3,6 +3,11 @@ name: Pytest on Unix OS
 on:
   workflow_call:
     inputs:
+      package_manager:
+        description: 'Package manager to use (eg. "conda", "poetry")'
+        required: true
+        type: string
+        default: 'poetry'
       python_ver:
         description: 'Matrix of Python versions to test against (eg. ["3.10", "3.11", "3.12"])'	
         required: false
@@ -22,7 +27,7 @@ on:
 jobs:
   pytest:
     name: pytest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.draft == false) }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,35 +37,30 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      POETRY_VIRTUALENVS_CREATE: true
-      POETRY_VIRTUALENVS_IN_PROJECT: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_ver }}
-      - name: Get full Python version
-        id: full-python-version
-        run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-      - name: Set up cache
-        uses: actions/cache@v4
-        id: cache
-        env:
-          # Increase this value to reset cache if poetry.lock has not changed
-          CACHE_NUMBER: ${{ inputs.cache_number }}
+      
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@DEVOPS-459
+        name: Setup conda env
+        if: ${{ inputs.package_manager == 'conda' }}
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}-{{ env.CACHE_NUMBER }}
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: timeout 10s poetry run pip --version || rm -rf .venv
-      - name: Install dependencies
-        run: poetry install -vvv
-      - name: pytest
-        run: poetry run pytest --cov-report=xml
+          python_ver: ${{ matrix.python_ver }}
+          shell_type: 'powershell'
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
+        name: Setup poetry env
+        if: ${{ inputs.package_manager == 'poetry' }}
+        with:
+          python_ver: ${{ matrix.python_ver }}
+          cache_number: ${{ inputs.cache_number }}
+          runner_os: ${{ runner.os }}
+        
+      - name: Run Pytest (with poetry)
+        if : ${{ inputs.package_manager == 'poetry' }}
+        run: poetry run pytest --cov --cov-report=xml
+      - name: Run Pytest (with conda)
+        if : ${{ inputs.package_manager == 'conda' }}
+        run: pytest --cov --cov-report=xml

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: number
         default: 1
+      shell_type:
+        description: 'Shell type to use'
+        required: false
+        type: string
+        default: 'bash'
 
 jobs:
   pytest:
@@ -36,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: bash
+        shell: ${{ inputs.shell_type }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version
@@ -49,7 +54,7 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: 'bash'
+          shell_type: ${{ inputs.shell_type }}
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}
@@ -58,13 +63,7 @@ jobs:
           cache_number: ${{ inputs.cache_number }}
           runner_os: ${{ runner.os }}
         
-      - name: Run Pytest (with poetry)
-        if : ${{ inputs.package_manager == 'poetry' }}
-        run: |
-          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
-          $(${RUNNER} pytest --cov --cov-report=xml)
-      - name: Run Pytest (with conda)
-        if : ${{ inputs.package_manager == 'conda' }}
+      - name: Run Pytest
         run: |
           RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
           $(${RUNNER} pytest --cov --cov-report=xml)

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -64,9 +64,9 @@ jobs:
         
       - name: Run Pytest
         run: |
-          if ${{ inputs.package_manager == 'conda' }}; then
+          if (${{ inputs.package_manager == 'conda' }}) {
             pytest --cov --cov-report=xml
-          else
+          } else {
             poetry run pytest --cov --cov-report=xml
-          fi
+          }
         

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -64,9 +64,9 @@ jobs:
         
       - name: Run Pytest
         run: |
-          if (${{ inputs.package_manager == 'conda' }}) {
+          if ${{ inputs.package_manager == 'conda' }}; then
             pytest --cov --cov-report=xml
-          } else {
+          else
             poetry run pytest --cov --cov-report=xml
-          }
+          fi
         

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -64,6 +64,9 @@ jobs:
         
       - name: Run Pytest
         run: |
-          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
-          $(${RUNNER} pytest --cov --cov-report=xml)
+          if ${{ inputs.package_manager == 'conda' }}; then
+            pytest --cov --cov-report=xml
+          else
+            poetry run pytest --cov --cov-report=xml
+          fi
         

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: 'powershell'
+          shell_type: 'bash'
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}
@@ -60,7 +60,9 @@ jobs:
         
       - name: Run Pytest (with poetry)
         if : ${{ inputs.package_manager == 'poetry' }}
-        run: poetry run pytest --cov --cov-report=xml
+        run: |
+          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
+          $(${RUNNER} pytest --cov --cov-report=xml)
       - name: Run Pytest (with conda)
         if : ${{ inputs.package_manager == 'conda' }}
         run: |

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: number
         default: 1
+      shell_type:
+        description: 'Shell type to use'
+        required: false
+        type: string
+        default: 'bash'
 
 jobs:
   pytest:
@@ -36,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: bash
+        shell: ${{ inputs.shell_type }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           python_ver: ${{ matrix.python_ver }}
           cache_number: ${{ inputs.cache_number }}
+          runner_os: ${{ runner.os }}
       
       - name: Run Pytest (with poetry)
         if : ${{ inputs.package_manager == 'poetry' }}

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Run Pytest (with conda)
         if : ${{ inputs.package_manager == 'conda' }}
         run: pytest --cov --cov-report=xml
+        shell: powershell
       
       - name: Codecov
         if:  ${{ (inputs.codecov_reference_python_ver) && (matrix.python_ver == inputs.codecov_reference_python_ver) }}

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -45,20 +45,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_ver }}
+      
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@DEVOPS-459
+        name: Setup conda env
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
           shell_type: 'powershell'
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
+        name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: 'powershell'
           cache_number: ${{ inputs.cache_number }}
-          runner_os: ${{ runner.os }}
-      - name: pytest
+      
+      - name: Run Pytest (with poetry)
+        if : ${{ inputs.package_manager == 'poetry' }}
         run: poetry run pytest --cov --cov-report=xml
+      - name: Run Pytest (with conda)
+        if : ${{ inputs.package_manager == 'conda' }}
+        run: pytest --cov --cov-report=xml
+      
       - name: Codecov
         if:  ${{ inputs.codecov_reference_python_ver }} && matrix.python_ver == ${{inputs.codecov_reference_python_ver}}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -22,6 +22,11 @@ on:
         description: 'Python version to use as reference for Codecov'
         required: false
         type: string
+      shell_type:
+        description: 'Shell type to use'
+        required: false
+        type: string
+        default: 'bash'
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov token'
@@ -37,7 +42,7 @@ jobs:
         python_ver: ${{ fromJSON(inputs.python_ver) }}
     defaults:
       run:
-        shell: bash
+        shell: ${{ inputs.shell_type }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +56,7 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: 'powershell'
+          shell_type: ${{ inputs.shell_type }}
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   pytest:
     name: pytest (Windows)
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.draft == false) }}
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
         run: pytest --cov --cov-report=xml
       
       - name: Codecov
-        if:  ${{ inputs.codecov_reference_python_ver }} && matrix.python_ver == ${{inputs.codecov_reference_python_ver}}
+        if:  ${{ (inputs.codecov_reference_python_ver) && (matrix.python_ver == inputs.codecov_reference_python_ver) }}
         uses: codecov/codecov-action@v4
         with:
           name: GitHub

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -22,6 +22,11 @@ on:
         description: 'Python version to use as reference for Codecov'
         required: false
         type: string
+      shell_type:
+        description: 'Shell type to use'
+        required: false
+        type: string
+        default: 'bash'
 
     secrets:
       CODECOV_TOKEN:
@@ -38,7 +43,7 @@ jobs:
         python_ver: ${{ fromJSON(inputs.python_ver) }}
     defaults:
       run:
-        shell: bash
+        shell: ${{ inputs.shell_type }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -65,14 +65,18 @@ jobs:
           cache_number: ${{ inputs.cache_number }}
           runner_os: ${{ runner.os }}
       
-      - name: Run Pytest (with poetry)
-        if : ${{ inputs.package_manager == 'poetry' }}
-        run: poetry run pytest --cov --cov-report=xml
-      - name: Run Pytest (with conda)
-        if : ${{ inputs.package_manager == 'conda' }}
-        run: pytest --cov --cov-report=xml
-        shell: powershell
-      
+      # - name: Run Pytest (with poetry)
+      #   if : ${{ inputs.package_manager == 'poetry' }}
+      #   run: poetry run pytest --cov --cov-report=xml
+      # - name: Run Pytest (with conda)
+      #   if : ${{ inputs.package_manager == 'conda' }}
+      #   run: pytest --cov --cov-report=xml
+      #   shell: powershell
+      - name: Run Pytest
+        run: |
+          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
+          $(${RUNNER} pytest --cov --cov-report=xml)
+
       - name: Codecov
         if:  ${{ (inputs.codecov_reference_python_ver) && (matrix.python_ver == inputs.codecov_reference_python_ver) }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -3,6 +3,11 @@ name: Pytest on Windows
 on:
   workflow_call:
     inputs:
+      package_manager:
+        description: 'Package manager to use (eg. "conda", "poetry")'
+        required: true
+        type: string
+        default: 'poetry'
       python_ver:
         description: 'Matrix of Python versions to test against (eg. ["3.10", "3.11", "3.12"])'	
         required: false
@@ -34,40 +39,30 @@ jobs:
       run:
         shell: bash
     runs-on: windows-latest
-    env:
-      POETRY_VIRTUALENVS_CREATE: true
-      POETRY_VIRTUALENVS_IN_PROJECT: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_ver }}
-      - name: Get full Python version
-        id: full-python-version
-        run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-      - name: Set up cache
-        uses: actions/cache@v4
-        id: cache
-        env:
-          # Increase this value to reset cache if poetry.lock has not changed
-          CACHE_NUMBER: ${{ inputs.cache_number }}
+      - uses: ./.github/actions/reusable-python-setup_conda
+        if: ${{ inputs.package_manager == 'conda' }}
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}-{{ env.CACHE_NUMBER }}
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: timeout 10s poetry run pip --version || rm -rf .venv
-      - name: Install dependencies
-        run: poetry install -vvv
+          python_ver: ${{ matrix.python_ver }}
+          shell_type: 'powershell'
+          cache_number: ${{ inputs.cache_number }}
+          runner_os: ${{ runner.os }}
+      - uses: ./.github/actions/reusable-python-setup_poetry
+        if: ${{ inputs.package_manager == 'poetry' }}
+        with:
+          python_ver: ${{ matrix.python_ver }}
+          shell_type: 'powershell'
+          cache_number: ${{ inputs.cache_number }}
+          runner_os: ${{ runner.os }}
       - name: pytest
         run: poetry run pytest --cov --cov-report=xml
       - name: Codecov
-        if:  ${{ inputs.codecov_reference_python_ver }} && ${{ steps.codecov-check.outputs.launch_codecov }} && ${{success()}} && matrix.python_ver == ${{inputs.codecov_reference_python_ver}}
+        if:  ${{ inputs.codecov_reference_python_ver }} && matrix.python_ver == ${{inputs.codecov_reference_python_ver}}
         uses: codecov/codecov-action@v4
         with:
           name: GitHub

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -22,11 +22,7 @@ on:
         description: 'Python version to use as reference for Codecov'
         required: false
         type: string
-      shell_type:
-        description: 'Shell type to use'
-        required: false
-        type: string
-        default: 'bash'
+
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov token'
@@ -42,7 +38,7 @@ jobs:
         python_ver: ${{ fromJSON(inputs.python_ver) }}
     defaults:
       run:
-        shell: ${{ inputs.shell_type }}
+        shell: bash
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +52,6 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: bash
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}
@@ -67,11 +62,11 @@ jobs:
       
       - name: Run Pytest
         run: |
-          if (${{ inputs.package_manager == 'conda' }}) {
+          if ${{ inputs.package_manager == 'conda' }}; then
             pytest --cov --cov-report=xml
-          } else {
+          else
             poetry run pytest --cov --cov-report=xml
-          }
+          fi
       - name: Codecov
         if:  ${{ (inputs.codecov_reference_python_ver) && (matrix.python_ver == inputs.codecov_reference_python_ver) }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -67,11 +67,11 @@ jobs:
       
       - name: Run Pytest
         run: |
-          if ${{ inputs.package_manager == 'conda' }}; then
+          if (${{ inputs.package_manager == 'conda' }}) {
             pytest --cov --cov-report=xml
-          else
+          } else {
             poetry run pytest --cov --cov-report=xml
-          fi
+          }
       - name: Codecov
         if:  ${{ (inputs.codecov_reference_python_ver) && (matrix.python_ver == inputs.codecov_reference_python_ver) }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -26,7 +26,7 @@ on:
         description: 'Shell type to use'
         required: false
         type: string
-        default: 'powershell'
+        default: 'bash'
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov token'
@@ -56,7 +56,7 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: ${{ inputs.shell_type }}
+          shell_type: powershell
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}
@@ -67,9 +67,11 @@ jobs:
       
       - name: Run Pytest
         run: |
-          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
-          $(${RUNNER} pytest --cov --cov-report=xml)
-
+          if ${{ inputs.package_manager == 'conda' }}; then
+            pytest --cov --cov-report=xml
+          else
+            poetry run pytest --cov --cov-report=xml
+          fi
       - name: Codecov
         if:  ${{ (inputs.codecov_reference_python_ver) && (matrix.python_ver == inputs.codecov_reference_python_ver) }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -65,13 +65,6 @@ jobs:
           cache_number: ${{ inputs.cache_number }}
           runner_os: ${{ runner.os }}
       
-      # - name: Run Pytest (with poetry)
-      #   if : ${{ inputs.package_manager == 'poetry' }}
-      #   run: poetry run pytest --cov --cov-report=xml
-      # - name: Run Pytest (with conda)
-      #   if : ${{ inputs.package_manager == 'conda' }}
-      #   run: pytest --cov --cov-report=xml
-      #   shell: powershell
       - name: Run Pytest
         run: |
           RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -26,7 +26,7 @@ on:
         description: 'Shell type to use'
         required: false
         type: string
-        default: 'bash'
+        default: 'powershell'
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov token'

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -26,7 +26,7 @@ on:
         description: 'Shell type to use'
         required: false
         type: string
-        default: 'powershell'
+        default: 'bash'
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov token'
@@ -56,7 +56,7 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
-          shell_type: powershell
+          shell_type: bash
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -45,14 +45,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_ver }}
-      - uses: ./.github/actions/reusable-python-setup_conda
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@DEVOPS-459
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ matrix.python_ver }}
           shell_type: 'powershell'
-          cache_number: ${{ inputs.cache_number }}
-          runner_os: ${{ runner.os }}
-      - uses: ./.github/actions/reusable-python-setup_poetry
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         if: ${{ inputs.package_manager == 'poetry' }}
         with:
           python_ver: ${{ matrix.python_ver }}

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: '3.10'
+      shell_type:
+        description: 'Shell type to use'
+        required: false
+        type: string
+        default: 'bash'
 
 env:
   source_dir: ${{ inputs.app_name }}
@@ -28,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash
+        shell: ${{ inputs.shell_type }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -61,14 +61,20 @@ jobs:
           && echo "FILES_PARAM=$(
           git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | grep -E "^(${source_dir}|tests)/.*\.py$" | xargs
           )" >> $GITHUB_ENV
+      
       - name: Run Pylint on modified files
         if: ${{ (github.event_name == 'pull_request') && env.FILES_PARAM }}
         run: |
-          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
-          $(${RUNNER} pylint $FILES_PARAM)
-      - name: Run Pylint on modified files (with Conda)
-        if: ${{ (inputs.package_manager == 'conda') && (github.event_name == 'pull_request') && env.FILES_PARAM }}
-        run: pylint $FILES_PARAM
-      - name: Run pylint on all files (with Conda)
-        if: ${{ (inputs.package_manager == 'conda') && (github.event_name == 'push') }}
-        run: pylint $source_dir tests
+          if ${{ inputs.package_manager == 'conda' }}; then
+            pylint $FILES_PARAM
+          else
+            poetry run pylint $FILES_PARAM
+          fi
+      
+      - name: Run Pylint on all files
+        run: |
+          if ${{ inputs.package_manager == 'conda' }}; then
+            pylint $source_dir tests
+          else
+            poetry run pylint $source_dir tests
+          fi

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -17,11 +17,6 @@ on:
         required: false
         type: string
         default: '3.10'
-      shell_type:
-        description: 'Shell type to use'
-        required: false
-        type: string
-        default: 'bash'
 
 env:
   source_dir: ${{ inputs.app_name }}
@@ -33,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: ${{ inputs.shell_type }}
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -46,7 +46,6 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ inputs.python_vers }}
-          # shell_type: '${{ inputs.shell_type }}'
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ inputs.python_vers }}
-          shell_type: '${{ inputs.shell_type }}'
+          # shell_type: '${{ inputs.shell_type }}'
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ inputs.package_manager == 'conda' }}
         with:
           python_ver: ${{ inputs.python_vers }}
-          shell_type: ${{ inputs.shell_type }}
+          shell_type: '${{ inputs.shell_type }}'
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -3,6 +3,11 @@ name: Static analysis
 on:
   workflow_call:
     inputs:
+      package_manager:
+        description: 'Package manager to use (eg. "conda", "poetry")'
+        required: true
+        type: string
+        default: 'poetry'
       app_name:
         description: 'Name of the app to run static analysis on'
         required: true
@@ -62,39 +67,39 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{inputs.python_vers}}
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | POETRY_HOME=$HOME/.poetry python -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-      - name: Set up cache
-        uses: actions/cache@v3
-        id: cache
-        env:
-          # Increase this value to reset cache if poetry.lock has not changed
-          CACHE_NUMBER: 1
+      
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@DEVOPS-459
+        name: Setup conda env
+        if: ${{ inputs.package_manager == 'conda' }}
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}-{{ env.CACHE_NUMBER }}
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
-        run: timeout 10s poetry run pip --version || rm -rf .venv
-      - name: Install dependencies
-        run: poetry install -vvv
-      - name: capture modified files
+          python_ver: ${{inputs.python_vers}}
+          shell_type: 'powershell'
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
+        name: Setup poetry env
+        if: ${{ inputs.package_manager == 'poetry' }}
+        with:
+          python_ver: ${{inputs.python_vers}}
+          shell_type: 'powershell'
+          cache_number: 1
+      
+      - name: Capture modified files
         if: github.event_name == 'pull_request'
         run: >-
           git fetch --deepen=500 origin ${{github.base_ref}}
           && echo "FILES_PARAM=$(
           git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | grep -E "^(${source_dir}|tests)/.*\.py$" | xargs
           )" >> $GITHUB_ENV
-      - name: Run pylint on modified files
-        if: github.event_name == 'pull_request' && env.FILES_PARAM
+      
+      - name: Run Pylint on modified files (with Poetry)
+        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'pull_request' && env.FILES_PARAM
         run: poetry run pylint $FILES_PARAM
-      - name: Run pylint on all files
-        if: github.event_name == 'push'
+      - name: Run pylint on all files (with Poetry)
+        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'push'
         run: poetry run pylint $source_dir tests
+      
+      - name: Run Pylint on modified files (with Conda)
+        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'pull_request' && env.FILES_PARAM
+        run: pylint $FILES_PARAM
+      - name: Run pylint on all files (with Conda)
+        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'push'
+        run: pylint $source_dir tests

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -29,9 +29,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      POETRY_VIRTUALENVS_CREATE: true
-      POETRY_VIRTUALENVS_IN_PROJECT: true
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -17,9 +17,14 @@ on:
         required: false
         type: string
         default: '3.10'
+      shell_type:
+        description: 'Shell type to use'
+        required: false
+        type: string
+        default: 'bash'
 
 env:
-  source_dir: ${{inputs.app_name}}
+  source_dir: ${{ inputs.app_name }}
 
 jobs:
   pylint:
@@ -28,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash
+        shell: ${{ inputs.shell_type }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python version
@@ -40,8 +45,8 @@ jobs:
         name: Setup conda env
         if: ${{ inputs.package_manager == 'conda' }}
         with:
-          python_ver: ${{inputs.python_vers}}
-          shell_type: 'powershell'
+          python_ver: ${{ inputs.python_vers }}
+          shell_type: ${{ inputs.shell_type }}
       - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@DEVOPS-459
         name: Setup poetry env
         if: ${{ inputs.package_manager == 'poetry' }}
@@ -57,14 +62,11 @@ jobs:
           && echo "FILES_PARAM=$(
           git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | grep -E "^(${source_dir}|tests)/.*\.py$" | xargs
           )" >> $GITHUB_ENV
-      
-      - name: Run Pylint on modified files (with Poetry)
-        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'pull_request') && env.FILES_PARAM }}
-        run: poetry run pylint $FILES_PARAM
-      - name: Run pylint on all files (with Poetry)
-        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'push') }}
-        run: poetry run pylint $source_dir tests
-      
+      - name: Run Pylint on modified files
+        if: ${{ (github.event_name == 'pull_request') && env.FILES_PARAM }}
+        run: |
+          RUNNER=$( ${{ inputs.package_manager == 'conda' }} ? '' : 'poetry run' })
+          $(${RUNNER} pylint $FILES_PARAM)
       - name: Run Pylint on modified files (with Conda)
         if: ${{ (inputs.package_manager == 'conda') && (github.event_name == 'pull_request') && env.FILES_PARAM }}
         run: pylint $FILES_PARAM

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -69,8 +69,8 @@ jobs:
         run: poetry run pylint $source_dir tests
       
       - name: Run Pylint on modified files (with Conda)
-        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'pull_request') && env.FILES_PARAM }}
+        if: ${{ (inputs.package_manager == 'conda') && (github.event_name == 'pull_request') && env.FILES_PARAM }}
         run: pylint $FILES_PARAM
       - name: Run pylint on all files (with Conda)
-        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'push') }}
+        if: ${{ (inputs.package_manager == 'conda') && (github.event_name == 'push') }}
         run: pylint $source_dir tests

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -22,35 +22,6 @@ env:
   source_dir: ${{inputs.app_name}}
 
 jobs:
-  pre-commit:
-    name: pre-commit
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    strategy:
-      fail-fast: false
-    runs-on: ubuntu-latest
-    env:
-      SKIP: pylint
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - name: capture modified files
-        if: github.event_name == 'pull_request'
-        run: >-
-          git fetch --deepen=500 origin ${{github.base_ref}}
-          && echo "FILES_PARAM=$(
-          git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | grep -E "^(${source_dir}|tests)/.*\.py$" | xargs
-          )" >> $GITHUB_ENV
-      - name: Run pre-commit on modified files
-        if: github.event_name == 'pull_request' && env.FILES_PARAM
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --hook-stage push --files ${{ env.FILES_PARAM }}
-      - name: Run pre-commit on all files
-        if: github.event_name == 'push'
-        uses: pre-commit/action@v3.0.0
-        with:
-          extra_args: --hook-stage push --all-files
-
   pylint:
     name: pylint
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
@@ -91,15 +62,15 @@ jobs:
           )" >> $GITHUB_ENV
       
       - name: Run Pylint on modified files (with Poetry)
-        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'pull_request'}} && env.FILES_PARAM
+        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'pull_request') && env.FILES_PARAM }}
         run: poetry run pylint $FILES_PARAM
       - name: Run pylint on all files (with Poetry)
-        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'push' }}
+        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'push') }}
         run: poetry run pylint $source_dir tests
       
       - name: Run Pylint on modified files (with Conda)
-        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'pull_request' }} && env.FILES_PARAM
+        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'pull_request') && env.FILES_PARAM }}
         run: pylint $FILES_PARAM
       - name: Run pylint on all files (with Conda)
-        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'push' }}
+        if: ${{ (inputs.package_manager == 'poetry') && (github.event_name == 'push') }}
         run: pylint $source_dir tests

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -79,8 +79,8 @@ jobs:
         if: ${{ inputs.package_manager == 'poetry' }}
         with:
           python_ver: ${{inputs.python_vers}}
-          shell_type: 'powershell'
           cache_number: 1
+          runner_os: ${{ runner.os }}
       
       - name: Capture modified files
         if: github.event_name == 'pull_request'
@@ -91,15 +91,15 @@ jobs:
           )" >> $GITHUB_ENV
       
       - name: Run Pylint on modified files (with Poetry)
-        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'pull_request' && env.FILES_PARAM
+        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'pull_request'}} && env.FILES_PARAM
         run: poetry run pylint $FILES_PARAM
       - name: Run pylint on all files (with Poetry)
-        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'push'
+        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'push' }}
         run: poetry run pylint $source_dir tests
       
       - name: Run Pylint on modified files (with Conda)
-        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'pull_request' && env.FILES_PARAM
+        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'pull_request' }} && env.FILES_PARAM
         run: pylint $FILES_PARAM
       - name: Run pylint on all files (with Conda)
-        if: ${{ inputs.package_manager == 'poetry' }} && github.event_name == 'push'
+        if: ${{ inputs.package_manager == 'poetry' }} && ${{ github.event_name == 'push' }}
         run: pylint $source_dir tests


### PR DESCRIPTION
- Create a pre-commit workflow: `reusable-pre_commit` (not directly in reusable-python-static_analysis as before)
- Manage conda and poetry packages:
        - Create reusable actions: `reusable-python-setup_poetry` and `reusable-python-setup_conda` to set up our Python environments through our workflows.
        - Modify `reusable-python-static_analysis`, `reusable-python-pytest_windows`, `reusable-python-pytest_unix_os` to use our actions.


Tested on [`python-poetry-template`](https://github.com/MiraGeoscience/python-poetry-template/actions/runs/10115365877) and [`python-conda-template`](https://github.com/MiraGeoscience/python-conda-template/actions/runs/10115407044)