### PR TITLE
DEVOPS-425: Add a python reusable workflow, which publish our package on Artifactory

### DIFF
--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -48,6 +48,14 @@ jobs:
                 uses: actions/checkout@v2
                 with:
                     lfs: ${{ inputs.lfs }}
+            -   name: Check if there is a conda recipe
+                run: |
+                    if [ -f ${{ inputs.package_name }}/meta.yaml ]; then
+                        echo "Conda recipe found"
+                    else
+                        echo "Conda recipe not found"
+                        exit 1
+                    fi
             -   name: Setup CONDA_LOCK_ENV_FILE
                 run: |
                     os_conda=$( [[ $RUNNER_OS == "Linux" ]] && echo "linux" || ([[ $RUNNER_OS == "Windows" ]] && echo "win" || echo "osx"))
@@ -58,11 +66,7 @@ jobs:
                 with:
                   python_ver: ${{ inputs.python_ver }}
             -   name: Install dependencies
-                run: conda install -y grayskull conda-build conda-verify
-            -   name: Generate conda recipe
-                run: |
-                    tar czf ../${{inputs.package_name}}.tar.gz .
-                    grayskull pypi ../${{ inputs.package_name }}.tar.gz
+                run: conda install -y conda-build conda-verify
             -   name: Build package
                 id: build_package
                 run: |

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -42,7 +42,7 @@ jobs:
                     conda install -y conda-build
             -   name: Generate conda recipe
                 run: |
-                    grayskull pypi --tag $version_tag ${{ inputs.package_name }}
+                    grayskull pypi --tag ${{ inputs.version_tag }} ${{ inputs.package_name }}
                     conda-build check ${{ inputs.package_name }}
             -   name: Build package
                 run: |

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -42,18 +42,22 @@ jobs:
                     conda install -y conda-build
             -   name: Generate conda recipe
                 run: |
-                    tar czf ${{inputs.package_name}}-${{inputs.version_tag}}.tar.gz .
+                    tar czf ../${{inputs.package_name}}-${{inputs.version_tag}}.tar.gz .
                     grayskull pypi --tag ${{ inputs.version_tag }} ./${{ inputs.package_name }}-${{ inputs.version_tag }}.tar.gz
             -   name: Build package
                 id: build_package
                 run: |
                     conda build ${{ inputs.package_name }}
                     build_path=$(conda build --output ${{ inputs.package_name }})
+                    build_name=$(basename ${build_path})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
+                    echo "BUILD_NAME=${build_name}" >> $GITHUB_OUTPUT
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
+                    echo "BUILD_NAME=${build_name}" >> $GITHUB_ENV	
             -   name: Test output
                 run: | 
                     echo ${{ env.BUILD_PATH }}
+                    echo ${{ env.BUILD_NAME }}
                     if test -f ${{ env.BUILD_PATH }}; then
                         echo "File exists"
                     else
@@ -62,7 +66,7 @@ jobs:
             -   name: Upload build package
                 uses: actions/upload-artifact@v4
                 with:
-                    name: build_package
+                    name: ${{ env.BUILD_NAME }}
                     path: ${{ env.BUILD_PATH }}
             # -   name: Check package
             #     run: |
@@ -77,11 +81,10 @@ jobs:
             -   name: Download build package
                 uses: actions/download-artifact@v4
                 with:
-                    name: build_package
+                    name: ${{ needs.build_package.outputs.BUILD_NAME }}
             -   name: Publish
                 run: |
-                    build_name=$(basename ${{ needs.build_package.outputs.BUILD_PATH }})
-                    curl -T ${{ needs.build_package.outputs.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${build_name}"
+                    curl -T ${{ needs.build_package.outputs.BUILD_NAME }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ needs.build_package.outputs.BUILD_NAME }}"
 
             
             

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -60,8 +60,8 @@ jobs:
             -   name: Build package
                 id: build_package
                 run: |
-                    conda build ${{ inputs.package_name }}
-                    build_path=$(conda build --output ${{ inputs.package_name }})
+                    micromamba build ${{ inputs.package_name }}
+                    build_path=$(micromamba build --output ${{ inputs.package_name }})
                     build_name=$(basename ${build_path})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
                     echo "BUILD_NAME=${build_name}" >> $GITHUB_ENV	
@@ -73,7 +73,7 @@ jobs:
                     retention-days: 7
             -   name: Publish on Artifactory
                 run: |
-                    curl -T ${{ env.BUILD_NAME }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"
+                    curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"
 
             
             

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -27,11 +27,7 @@ defaults:
 jobs:
     release_on_artifactory:
         name: Release package on Artifactory
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         env:
             PYTHONUTF8: 1
             CONDA_CHANNEL_PRIORITY: strict

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -55,16 +55,14 @@ jobs:
                     conda install -y conda-verify
             -   name: Generate conda recipe
                 run: |
-                    tar czf ../${{inputs.package_name}}-${{inputs.version_tag}}-${{ runner.os }}.tar.gz .
-                    grayskull pypi ../${{ inputs.package_name }}-${{ inputs.version_tag }}-${{ runner.os }}.tar.gz
+                    tar czf ../${{inputs.package_name}}.tar.gz .
+                    grayskull pypi ../${{ inputs.package_name }}.tar.gz
             -   name: Build package
                 id: build_package
                 run: |
                     conda build ${{ inputs.package_name }}
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     build_name=$(basename ${build_path})
-                    echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
-                    echo "BUILD_NAME=${build_name}" >> $GITHUB_OUTPUT
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
                     echo "BUILD_NAME=${build_name}" >> $GITHUB_ENV	
             -   name: Upload build package

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -20,11 +20,11 @@ on:
             required: false
             type: boolean
             default: false
-        MIRA_CONDA_REPO_NAME:
-            description: 'NAME of the extra repository on JFrog Artifactory'
+        MIRA_CONDA_REPO_URL:
+            description: 'URL of the extra repository on JFrog Artifactory'
             required: false
             type: string
-            default: 'analyst-dev-conda-local'
+            default: 'https://mirageoscienceltd.jfrog.io/ui/repos/tree/General/analyst-dev-conda-local'
 
     secrets:
         MIRA_CONDA_REPO_TOKEN:
@@ -83,4 +83,4 @@ jobs:
                     retention-days: 7
             -   name: Publish on Artifactory
                 run: |
-                    curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.MIRA_CONDA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/${{ inputs.MIRA_CONDA_REPO_NAME }}/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"
+                    curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.MIRA_CONDA_REPO_TOKEN }}" "${{ inputs.MIRA_CONDA_REPO_URL }}/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -2,14 +2,19 @@ name: Publish condan package to Artifactory
 
 on:
   workflow_call:
+    inputs:
+        package_name:
+            description: 'Name of the package to build'
+            required: true
+            type: string
+        version_tag:
+            description: 'Version tag of the package to build'
+            required: true
+            type: string
     secrets:
         EXTRA_REPO_TOKEN:
             description: 'Bearer token for the extra repository on JFrog Artifactory'
             required: true
-
-env:
-    PACKAGE_NAME: 'my_package'
-    VERSION_TAG: '0.1.0'
 
 defaults:
     run:
@@ -37,11 +42,11 @@ jobs:
                     conda install -y conda-build
             -   name: Generate conda recipe
                 run: |
-                    grayskull pypi --tag $version_tag $package_name
-                    conda-build check $package_name
+                    grayskull pypi --tag $version_tag ${{ inputs.package_name }}
+                    conda-build check ${{ inputs.package_name }}
             -   name: Build package
                 run: |
-                    build_path=$(conda build --output $package_name)
+                    build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
             -   name: Check package
                 run: |
@@ -52,8 +57,8 @@ jobs:
         steps:
             -   name: Publish
                 run: |
-                    build_name=$(basename ${{env.BUILD_PATH}})
-                    curl -T ${{env.BUILD_PATH}} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ github.env.PACKAGE_NAME }}/${{ github.env.VERSION_TAG }}/${build_name}"
+                    build_name=$(basename ${{ env.BUILD_PATH }})
+                    curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${build_name}"
 
             
             

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -49,6 +49,14 @@ jobs:
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
+            -   name: Test output
+                run: | 
+                    echo ${{ github.env.BUILD_PATH }}
+                    if test -f ${{ github.env.BUILD_PATH }}; then
+                        echo "File exists"
+                    else
+                        echo "File does not exist"
+                    fi
             -   name: Upload build package
                 uses: actions/upload-artifact@v4
                 with:

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -51,8 +51,8 @@ jobs:
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
             -   name: Test output
                 run: | 
-                    echo ${{ github.env.BUILD_PATH }}
-                    if test -f ${{ github.env.BUILD_PATH }}; then
+                    echo ${{ env.BUILD_PATH }}
+                    if test -f ${{ env.BUILD_PATH }}; then
                         echo "File exists"
                     else
                         echo "File does not exist"
@@ -61,7 +61,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 with:
                     name: build_package
-                    path: ${{ github.env.BUILD_PATH }}
+                    path: ${{ env.BUILD_PATH }}
             # -   name: Check package
             #     run: |
             #         conda install $BUILD_PATH

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
     build_package:
         name: build package
-        runs-on: windows-latest
+        runs-on: ubuntu-latest
         env:
             PYTHONUTF8: 1
             CONDA_CHANNEL_PRIORITY: strict

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -7,6 +7,10 @@ on:
             description: 'Name of the package to build'
             required: true
             type: string
+        python_ver:
+            description: 'Python version to use (eg: 3.10)'
+            required: true
+            type: string
         version_tag:
             description: 'Version tag of the package to build'
             required: true
@@ -23,27 +27,35 @@ defaults:
 jobs:
     build_package:
         name: build package
-        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-lastest, windows-latest]
+        runs-on: ${{ matrix.os }}
         env:
             PYTHONUTF8: 1
             CONDA_CHANNEL_PRIORITY: strict
             PIP_NO_DEPS: 1 # all dependencies are installed from conda
-            CONDA_LOCK_ENV_FILE: environments/py-3.10-linux-64-dev.conda.lock.yml
         steps:
             -   name: Checkout
                 uses: actions/checkout@v2
+            -   name: Setup CONDA_LOCK_ENV_FILE
+                run: |
+                    os_conda=$( [[ $RUNNER_OS == "Linux" ]] && echo "linux" || ([[ $RUNNER_OS == "Windows" ]] && echo "win" || echo "osx"))
+                    echo "CONDA_LOCK_ENV_FILE=environments/py-${{ inputs.python_ver }}-${os_conda}-64-dev.conda.lock.yml" >> $GITHUB_ENV
             -   uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@main
                 name: Setup conda env
                 with:
-                  python_ver: '3.10'
+                  python_ver: ${{ inputs.python_ver }}
             -   name: Install dependencies
                 run: |
                     conda install -y grayskull
                     conda install -y conda-build
+                    conda install -y conda-verify
             -   name: Generate conda recipe
                 run: |
                     tar czf ../${{inputs.package_name}}-${{inputs.version_tag}}.tar.gz .
-                    grayskull pypi --tag ${{ inputs.version_tag }} ../${{ inputs.package_name }}-${{ inputs.version_tag }}.tar.gz
+                    grayskull pypi ../${{ inputs.package_name }}-${{ inputs.version_tag }}.tar.gz
             -   name: Build package
                 id: build_package
                 run: |
@@ -54,24 +66,12 @@ jobs:
                     echo "BUILD_NAME=${build_name}" >> $GITHUB_OUTPUT
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
                     echo "BUILD_NAME=${build_name}" >> $GITHUB_ENV	
-            -   name: Test output
-                run: | 
-                    echo ${{ env.BUILD_PATH }}
-                    echo ${{ env.BUILD_NAME }}
-                    if test -f ${{ env.BUILD_PATH }}; then
-                        echo "File exists"
-                    else
-                        echo "File does not exist"
-                    fi
             -   name: Upload build package
                 uses: actions/upload-artifact@v4
                 with:
                     name: ${{ env.BUILD_NAME }}
                     path: ${{ env.BUILD_PATH }}
                     retention-days: 7
-            # -   name: Check package
-            #     run: |
-            #         conda install $BUILD_PATH
         outputs:
             BUILD_PATH: ${{ steps.build_package.outputs.BUILD_PATH }}
             BUILD_NAME: ${{ steps.build_package.outputs.BUILD_NAME }}

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -47,7 +47,7 @@ jobs:
             -   name: Build package
                 id: build_package
                 run: |
-                    conda build ${{ inputs.package_name }}
+                    conda build --build-only ${{ inputs.package_name }}
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -48,6 +48,7 @@ jobs:
                 run: |
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
+                    echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
             -   name: Upload build package
                 uses: actions/upload-artifact@v4
                 with:

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -43,7 +43,7 @@ jobs:
             -   name: Generate conda recipe
                 run: |
                     tar czf ../${{inputs.package_name}}-${{inputs.version_tag}}.tar.gz .
-                    grayskull pypi --tag ${{ inputs.version_tag }} ./${{ inputs.package_name }}-${{ inputs.version_tag }}.tar.gz
+                    grayskull pypi --tag ${{ inputs.version_tag }} ../${{ inputs.package_name }}-${{ inputs.version_tag }}.tar.gz
             -   name: Build package
                 id: build_package
                 run: |
@@ -68,6 +68,7 @@ jobs:
                 with:
                     name: ${{ env.BUILD_NAME }}
                     path: ${{ env.BUILD_PATH }}
+                    retention-days: 7
             # -   name: Check package
             #     run: |
             #         conda install $BUILD_PATH

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -70,6 +70,3 @@ jobs:
             -   name: Publish on Artifactory
                 run: |
                     curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"
-
-            
-            

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -1,0 +1,59 @@
+name: Publish condan package to Artifactory 
+
+on:
+  workflow_call:
+    secrets:
+        EXTRA_REPO_TOKEN:
+            description: 'Bearer token for the extra repository on JFrog Artifactory'
+            required: true
+
+env:
+    PACKAGE_NAME: 'my_package'
+    VERSION_TAG: '0.1.0'
+
+defaults:
+    run:
+        shell: 'bash -l {0}'
+
+jobs:
+    build-package:
+        name: build package
+        runs-on: ubuntu-latest
+        env:
+            PYTHONUTF8: 1
+            CONDA_CHANNEL_PRIORITY: strict
+            PIP_NO_DEPS: 1 # all dependencies are installed from conda
+            CONDA_LOCK_ENV_FILE: environments/py-3.10-linux-64-dev.conda.lock.yml
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+            -   uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@main
+                name: Setup conda env
+                with:
+                  python_ver: '3.10'
+            -   name: Install dependencies
+                run: |
+                    conda intall -y grayskull
+                    conda install -y conda-build
+            -   name: Generate conda recipe
+                run: |
+                    grayskull pypi --tag $version_tag $package_name
+                    conda-build check $package_name
+            -   name: Build package
+                run: |
+                    build_path=$(conda build --output $package_name)
+                    echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
+            -   name: Check package
+                run: |
+                    conda install $BUILD_PATH
+    publish_package:
+        name: publish package on artifactory
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Publish
+                run: |
+                    build_name=$(basename ${{env.BUILD_PATH}})
+                    curl -T ${{env.BUILD_PATH}} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ github.env.PACKAGE_NAME }}/${{ github.env.VERSION_TAG }}/${build_name}"
+
+            
+            

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -30,7 +30,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-latest]
         runs-on: ${{ matrix.os }}
         env:
             PYTHONUTF8: 1
@@ -60,8 +60,8 @@ jobs:
             -   name: Build package
                 id: build_package
                 run: |
-                    micromamba build ${{ inputs.package_name }}
-                    build_path=$(micromamba build --output ${{ inputs.package_name }})
+                    conda build ${{ inputs.package_name }}
+                    build_path=$(conda build --output ${{ inputs.package_name }})
                     build_name=$(basename ${build_path})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
                     echo "BUILD_NAME=${build_name}" >> $GITHUB_ENV	

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
     build_package:
         name: build package
-        runs-on: ubuntu-latest
+        runs-on: windows-latest
         env:
             PYTHONUTF8: 1
             CONDA_CHANNEL_PRIORITY: strict

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -15,8 +15,19 @@ on:
             description: 'Version tag of the package to build'
             required: true
             type: string
+        lfs:
+            description: 'Boolean to indicate if Github LFS is needed'
+            required: false
+            type: boolean
+            default: false
+        MIRA_CONDA_REPO_NAME:
+            description: 'NAME of the extra repository on JFrog Artifactory'
+            required: false
+            type: string
+            default: 'analyst-dev-conda-local'
+
     secrets:
-        EXTRA_REPO_TOKEN:
+        MIRA_CONDA_REPO_TOKEN:
             description: 'Bearer token for the extra repository on JFrog Artifactory'
             required: true
 
@@ -35,6 +46,8 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@v2
+                with:
+                    lfs: ${{ inputs.lfs }}
             -   name: Setup CONDA_LOCK_ENV_FILE
                 run: |
                     os_conda=$( [[ $RUNNER_OS == "Linux" ]] && echo "linux" || ([[ $RUNNER_OS == "Windows" ]] && echo "win" || echo "osx"))
@@ -45,10 +58,7 @@ jobs:
                 with:
                   python_ver: ${{ inputs.python_ver }}
             -   name: Install dependencies
-                run: |
-                    conda install -y grayskull
-                    conda install -y conda-build
-                    conda install -y conda-verify
+                run: conda install -y grayskull conda-build conda-verify
             -   name: Generate conda recipe
                 run: |
                     tar czf ../${{inputs.package_name}}.tar.gz .
@@ -69,4 +79,4 @@ jobs:
                     retention-days: 7
             -   name: Publish on Artifactory
                 run: |
-                    curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"
+                    curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.MIRA_CONDA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/${{ inputs.MIRA_CONDA_REPO_NAME }}/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -46,6 +46,7 @@ jobs:
             -   name: Build package
                 id: build_package
                 run: |
+                    conda build ${{ inputs.package_name }}
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -42,7 +42,8 @@ jobs:
                     conda install -y conda-build
             -   name: Generate conda recipe
                 run: |
-                    grayskull pypi --tag ${{ inputs.version_tag }} ${{ inputs.package_name }}
+                    python -m build -s
+                    grayskull pypi --tag ${{ inputs.version_tag }} ./dist/*.tar.gz
             -   name: Build package
                 id: build_package
                 run: |

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -21,7 +21,7 @@ defaults:
         shell: 'bash -l {0}'
 
 jobs:
-    build-package:
+    build_package:
         name: build package
         runs-on: ubuntu-latest
         env:
@@ -53,6 +53,7 @@ jobs:
                     conda install $BUILD_PATH
     publish_package:
         name: publish package on artifactory
+        needs: build_package
         runs-on: ubuntu-latest
         steps:
             -   name: Publish

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -48,6 +48,11 @@ jobs:
                 run: |
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
+            -   name: Upload build package
+                uses: actions/upload-artifact@v4
+                with:
+                    name: build_package
+                    path: ${{ github.env.BUILD_PATH }}
             # -   name: Check package
             #     run: |
             #         conda install $BUILD_PATH
@@ -58,6 +63,11 @@ jobs:
         needs: build_package
         runs-on: ubuntu-latest
         steps:
+            -   name: Download build package
+                uses: actions/download-artifact@v4
+                with:
+                    name: build_package
+                uses: actions/checkout@v2
             -   name: Publish
                 run: |
                     build_name=$(basename ${{ needs.build_package.outputs.BUILD_PATH }})

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -42,8 +42,8 @@ jobs:
                     conda install -y conda-build
             -   name: Generate conda recipe
                 run: |
-                    poetry build
-                    grayskull pypi --tag ${{ inputs.version_tag }} ./dist/*.tar.gz
+                    tar czf ${{inputs.package_name}}-${{inputs.version_tag}}.tar.gz .
+                    grayskull pypi --tag ${{ inputs.version_tag }} ./${{ inputs.package_name }}-${{ inputs.version_tag }}.tar.gz
             -   name: Build package
                 id: build_package
                 run: |

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -42,7 +42,7 @@ jobs:
                     conda install -y conda-build
             -   name: Generate conda recipe
                 run: |
-                    python -m build -s
+                    poetry build
                     grayskull pypi --tag ${{ inputs.version_tag }} ./dist/*.tar.gz
             -   name: Build package
                 id: build_package

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -38,7 +38,7 @@ jobs:
                   python_ver: '3.10'
             -   name: Install dependencies
                 run: |
-                    conda intall -y grayskull
+                    conda install -y grayskull
                     conda install -y conda-build
             -   name: Generate conda recipe
                 run: |

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -47,7 +47,7 @@ jobs:
                 id: build_package
                 run: |
                     build_path=$(conda build --output ${{ inputs.package_name }})
-                    echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
+                    echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
             # -   name: Check package
             #     run: |
             #         conda install $BUILD_PATH

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -43,7 +43,6 @@ jobs:
             -   name: Generate conda recipe
                 run: |
                     grayskull pypi --tag ${{ inputs.version_tag }} ${{ inputs.package_name }}
-                    conda-build check ${{ inputs.package_name }}
             -   name: Build package
                 run: |
                     build_path=$(conda build --output ${{ inputs.package_name }})

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -47,7 +47,7 @@ jobs:
             -   name: Build package
                 id: build_package
                 run: |
-                    conda build --build-only ${{ inputs.package_name }}
+                    conda build ${{ inputs.package_name }}
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_OUTPUT
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -25,12 +25,12 @@ defaults:
         shell: 'bash -l {0}'
 
 jobs:
-    build_package:
-        name: build package
+    release_on_artifactory:
+        name: Release package on Artifactory
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-lastest, windows-latest]
+                os: [ubuntu-latest, windows-latest]
         runs-on: ${{ matrix.os }}
         env:
             PYTHONUTF8: 1
@@ -42,6 +42,7 @@ jobs:
             -   name: Setup CONDA_LOCK_ENV_FILE
                 run: |
                     os_conda=$( [[ $RUNNER_OS == "Linux" ]] && echo "linux" || ([[ $RUNNER_OS == "Windows" ]] && echo "win" || echo "osx"))
+                    
                     echo "CONDA_LOCK_ENV_FILE=environments/py-${{ inputs.python_ver }}-${os_conda}-64-dev.conda.lock.yml" >> $GITHUB_ENV
             -   uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@main
                 name: Setup conda env
@@ -54,8 +55,8 @@ jobs:
                     conda install -y conda-verify
             -   name: Generate conda recipe
                 run: |
-                    tar czf ../${{inputs.package_name}}-${{inputs.version_tag}}.tar.gz .
-                    grayskull pypi ../${{ inputs.package_name }}-${{ inputs.version_tag }}.tar.gz
+                    tar czf ../${{inputs.package_name}}-${{inputs.version_tag}}-${{ runner.os }}.tar.gz .
+                    grayskull pypi ../${{ inputs.package_name }}-${{ inputs.version_tag }}-${{ runner.os }}.tar.gz
             -   name: Build package
                 id: build_package
                 run: |
@@ -72,21 +73,9 @@ jobs:
                     name: ${{ env.BUILD_NAME }}
                     path: ${{ env.BUILD_PATH }}
                     retention-days: 7
-        outputs:
-            BUILD_PATH: ${{ steps.build_package.outputs.BUILD_PATH }}
-            BUILD_NAME: ${{ steps.build_package.outputs.BUILD_NAME }}
-    publish_package:
-        name: publish package on artifactory
-        needs: build_package
-        runs-on: ubuntu-latest
-        steps:
-            -   name: Download build package
-                uses: actions/download-artifact@v4
-                with:
-                    name: ${{ needs.build_package.outputs.BUILD_NAME }}
-            -   name: Publish
+            -   name: Publish on Artifactory
                 run: |
-                    curl -T ${{ needs.build_package.outputs.BUILD_NAME }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ needs.build_package.outputs.BUILD_NAME }}"
+                    curl -T ${{ env.BUILD_NAME }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${{ env.BUILD_NAME }}"
 
             
             

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -44,12 +44,15 @@ jobs:
                 run: |
                     grayskull pypi --tag ${{ inputs.version_tag }} ${{ inputs.package_name }}
             -   name: Build package
+                id: build_package
                 run: |
                     build_path=$(conda build --output ${{ inputs.package_name }})
                     echo "BUILD_PATH=${build_path}" >> $GITHUB_ENV
-            -   name: Check package
-                run: |
-                    conda install $BUILD_PATH
+            # -   name: Check package
+            #     run: |
+            #         conda install $BUILD_PATH
+        outputs:
+            BUILD_PATH: ${{ steps.build_package.outputs.BUILD_PATH }}
     publish_package:
         name: publish package on artifactory
         needs: build_package
@@ -57,8 +60,8 @@ jobs:
         steps:
             -   name: Publish
                 run: |
-                    build_name=$(basename ${{ env.BUILD_PATH }})
-                    curl -T ${{ env.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${build_name}"
+                    build_name=$(basename ${{ needs.build_package.outputs.BUILD_PATH }})
+                    curl -T ${{ needs.build_package.outputs.BUILD_PATH }} -H "Authorization: Bearer ${{ secrets.EXTRA_REPO_TOKEN }}" "https://mirageoscienceltd.jfrog.io/artifactory/analyst-dev-conda-local/${{ inputs.package_name }}/${{ inputs.version_tag }}/${build_name}"
 
             
             

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -74,6 +74,7 @@ jobs:
             #         conda install $BUILD_PATH
         outputs:
             BUILD_PATH: ${{ steps.build_package.outputs.BUILD_PATH }}
+            BUILD_NAME: ${{ steps.build_package.outputs.BUILD_NAME }}
     publish_package:
         name: publish package on artifactory
         needs: build_package

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -67,7 +67,6 @@ jobs:
                 uses: actions/download-artifact@v4
                 with:
                     name: build_package
-                uses: actions/checkout@v2
             -   name: Publish
                 run: |
                     build_name=$(basename ${{ needs.build_package.outputs.BUILD_PATH }})


### PR DESCRIPTION
**DEVOPS-425 - auto-publish conda package to Artifactory upon version tag**
- Generate recipe with `grayskull`
- Build package with `conda build`  (so we cannot use lock file)
- Create an artifactory on github with our package (`.tar.gz`) which stay for a week (could be usefull if the uploading on artifactory doesn't work)
- Upload on the repo `analyst-dev-conda-local`

**Test on [geoapps-utils](https://github.com/MiraGeoscience/geoapps-utils/actions/runs/10221287753)**