### PR TITLE
DEVOPS-459: Add a git lfs option for unix and windows pytest workflow

### DIFF
--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -28,6 +28,12 @@ on:
         required: false
         type: boolean
         default: false
+      lfs:
+        description: 'Boolean to indicate if Github LFS is needed'
+        required: false
+        type: boolean
+        default: false
+
     secrets:
       EXTRA_PYPI_REPO_USER:
         description: 'Extra PyPI repository username. Only used if `extra_repository` is True.'
@@ -51,6 +57,8 @@ jobs:
         shell: 'bash -l {0}'
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: ${{ inputs.lfs }}
       - name: Set up Python version
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: false
+      lfs:
+        description: 'Boolean to indicate if Github LFS is needed'
+        required: false
+        type: boolean
+        default: false
 
     secrets:
       CODECOV_TOKEN:
@@ -54,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: ${{ inputs.lfs }}
       - name: Set up Python version
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -53,6 +53,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Set up Python version
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
**DEVOPS-459 - Modify reusable-python-static_analys workflow to manage conda package**

Test on [targeting-workflows](https://github.com/MiraGeoscience/targeting-workflow/actions/runs/10253328623?pr=107)