### PR TITLE
DEVOPS-439: Add hatch as package manager

### DIFF
--- a/.github/actions/reusable-python-setup_hatch/action.yml
+++ b/.github/actions/reusable-python-setup_hatch/action.yml
@@ -1,0 +1,34 @@
+name: Setup hatch env
+description: Setup hatch environment for Python
+inputs:
+  cache_number:
+    description: 'Cache number to reset cache if pyproject.toml has not changed'
+    required: true
+    type: number
+  runner_os:
+    description: 'Runner OS'
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get full Python version
+      id: full-python-version
+      run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Set up cache
+      uses: actions/cache@v4
+      id: cache
+      env:
+        CACHE_NUMBER: ${{ inputs.cache_number }}
+      with:
+        path: ~/.cache/pip
+        key: venv-${{ inputs.runner_os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('piproject.toml') }}-${{ inputs.CACHE_NUMBER }}
+    - name: Ensure cache is healthy
+      if: steps.cache.outputs.cache-hit == 'true'
+      run: timeout 10s poetry run pip --version || rm -rf .venv
+      shell: bash
+    - name: Install hatch
+      run: pip install hatch
+      shell: bash

--- a/.github/actions/reusable-python-setup_hatch/action.yml
+++ b/.github/actions/reusable-python-setup_hatch/action.yml
@@ -20,11 +20,9 @@ runs:
     - name: Set up cache
       uses: actions/cache@v4
       id: cache
-      env:
-        CACHE_NUMBER: ${{ inputs.cache_number }}
       with:
         path: ~/.cache/pip
-        key: venv-${{ inputs.runner_os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('piproject.toml') }}-${{ inputs.CACHE_NUMBER }}
+        key: venv-${{ inputs.runner_os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('piproject.toml') }}-${{ inputs.cache_number }}
     - name: Ensure cache is healthy
       if: steps.cache.outputs.cache-hit == 'true'
       run: timeout 10s poetry run pip --version || rm -rf .venv

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.lfs }}
+          fetch-depth: 0
       - name: Set up Python version
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -80,7 +80,7 @@ jobs:
           extra_repository: ${{ inputs.extra_repository }}
           repo_user: ${{ secrets.EXTRA_PYPI_REPO_USER }}
           repo_token: ${{ secrets.EXTRA_PYPI_REPO_TOKEN }}
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@DEVOPS-439
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@main
         name: Setup hatch env
         if: ${{ inputs.package_manager == 'hatch' }}
         with:

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -79,12 +79,19 @@ jobs:
           extra_repository: ${{ inputs.extra_repository }}
           repo_user: ${{ secrets.EXTRA_PYPI_REPO_USER }}
           repo_token: ${{ secrets.EXTRA_PYPI_REPO_TOKEN }}
-        
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@DEVOPS-439
+        name: Setup hatch env
+        if: ${{ inputs.package_manager == 'hatch' }}
+        with:
+          cache_number: ${{ inputs.cache_number }}
+
       - name: Run Pytest
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pytest --cov --cov-report=xml
-          else
+          else if ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pytest --cov --cov-report=xml
+          else
+            hatch run pytest --cov --cov-report=xml
           fi
         

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -84,12 +84,13 @@ jobs:
         if: ${{ inputs.package_manager == 'hatch' }}
         with:
           cache_number: ${{ inputs.cache_number }}
+          runner_os: ${{ runner.os }}
 
       - name: Run Pytest
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pytest --cov --cov-report=xml
-          else if ${{ inputs.package_manager == 'poetry' }}; then
+          elif ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pytest --cov --cov-report=xml
           else
             hatch run pytest --cov --cov-report=xml

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -85,12 +85,13 @@ jobs:
         if: ${{ inputs.package_manager == 'hatch' }}
         with:
           cache_number: ${{ inputs.cache_number }}
+          runner_os: ${{ runner.os }}
       
       - name: Run Pytest
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pytest --cov --cov-report=xml
-          else if ${{ inputs.package_manager == 'poetry' }}; then
+          elif ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pytest --cov --cov-report=xml
           else
             hatch run pytest --cov --cov-report=xml

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.lfs }}
+          fetch-depth: 0
       - name: Set up Python version
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -80,13 +80,20 @@ jobs:
           extra_repository: ${{ inputs.extra_repository }}
           repo_user: ${{ secrets.EXTRA_PYPI_REPO_USER }}
           repo_token: ${{ secrets.EXTRA_PYPI_REPO_TOKEN }}
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@DEVOPS-439
+        name: Setup hatch env
+        if: ${{ inputs.package_manager == 'hatch' }}
+        with:
+          cache_number: ${{ inputs.cache_number }}
       
       - name: Run Pytest
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pytest --cov --cov-report=xml
-          else
+          else if ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pytest --cov --cov-report=xml
+          else
+            hatch run pytest --cov --cov-report=xml
           fi
       - name: Codecov
         if:  ${{ (inputs.codecov_reference_python_ver) && (matrix.python_ver == inputs.codecov_reference_python_ver) }}

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -81,7 +81,7 @@ jobs:
           extra_repository: ${{ inputs.extra_repository }}
           repo_user: ${{ secrets.EXTRA_PYPI_REPO_USER }}
           repo_token: ${{ secrets.EXTRA_PYPI_REPO_TOKEN }}
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@DEVOPS-439
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@main
         name: Setup hatch env
         if: ${{ inputs.package_manager == 'hatch' }}
         with:

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -68,6 +68,7 @@ jobs:
         if: ${{ inputs.package_manager == 'hatch' }}
         with:
           cache_number: 1
+          runner_os: ${{ runner.os }}
 
       - name: Capture modified files
         if: github.event_name == 'pull_request'
@@ -82,7 +83,7 @@ jobs:
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pylint $FILES_PARAM
-          else if ${{ inputs.package_manager == 'poetry' }}; then
+          elif ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pylint $FILES_PARAM
           else 
             hatch run pylint $FILES_PARAM
@@ -92,7 +93,7 @@ jobs:
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pylint $source_dir tests
-          else if ${{ inputs.package_manager == 'poetry' }}; then
+          elif ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pylint $source_dir tests
           else
             hatch run pylint $source_dir tests

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -65,7 +65,7 @@ jobs:
           extra_repository: ${{ inputs.extra_repository }}
           repo_user: ${{ secrets.EXTRA_PYPI_REPO_USER }}
           repo_token: ${{ secrets.EXTRA_PYPI_REPO_TOKEN }}
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@DEVOPS-439
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@main
         name: Setup hatch env
         if: ${{ inputs.package_manager == 'hatch' }}
         with:

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -43,6 +43,8 @@ jobs:
         shell: 'bash -l {0}'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python version
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -63,7 +63,12 @@ jobs:
           extra_repository: ${{ inputs.extra_repository }}
           repo_user: ${{ secrets.EXTRA_PYPI_REPO_USER }}
           repo_token: ${{ secrets.EXTRA_PYPI_REPO_TOKEN }}
-      
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@DEVOPS-439
+        name: Setup hatch env
+        if: ${{ inputs.package_manager == 'hatch' }}
+        with:
+          cache_number: 1
+
       - name: Capture modified files
         if: github.event_name == 'pull_request'
         run: >-

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -82,14 +82,18 @@ jobs:
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pylint $FILES_PARAM
-          else
+          else if ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pylint $FILES_PARAM
+          else 
+            hatch run pylint $FILES_PARAM
           fi
       
       - name: Run Pylint on all files
         run: |
           if ${{ inputs.package_manager == 'conda' }}; then
             pylint $source_dir tests
-          else
+          else if ${{ inputs.package_manager == 'poetry' }}; then
             poetry run pylint $source_dir tests
+          else
+            hatch run pylint $source_dir tests
           fi


### PR DESCRIPTION
**DEVOPS-439: Add hatch as package manager**

- Create an action named setup hatch
- Add a condition on the package manager inside `pytest_unix`, `pytest_windows` and `static_analysis`

✅ Test on `geoh5py` ([PR590](https://github.com/MiraGeoscience/geoh5py/actions/runs/10271459513?pr=590))