### PR TITLE
DEVOPS-460: Add a timeout for every jobs in reusable workflows

### DIFF
--- a/.github/workflows/reusable-jira-issue_to_jira.yml
+++ b/.github/workflows/reusable-jira-issue_to_jira.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   new_jira_issue:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: JIRA Login
       uses: atlassian/gajira-login@v3.0.1

--- a/.github/workflows/reusable-jira-pr_add_jira_summary.yml
+++ b/.github/workflows/reusable-jira-pr_add_jira_summary.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   add_jira_summary:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 20
     steps:
     - name: Find JIRA issue key
       id: find_jira_key

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP: pylint
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/reusable-python-publish_to_artifactory.yml
+++ b/.github/workflows/reusable-python-publish_to_artifactory.yml
@@ -43,6 +43,7 @@ jobs:
             PYTHONUTF8: 1
             CONDA_CHANNEL_PRIORITY: strict
             PIP_NO_DEPS: 1 # all dependencies are installed from conda
+        timeout-minutes: 20
         steps:
             -   name: Checkout
                 uses: actions/checkout@v2

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -55,6 +55,7 @@ jobs:
     defaults:
       run:
         shell: 'bash -l {0}'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -55,6 +55,7 @@ jobs:
     defaults:
       run:
         shell: 'bash -l {0}'
+    timeout-minutes: 20
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -41,6 +41,7 @@ jobs:
     defaults:
       run:
         shell: 'bash -l {0}'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**DEVOPS-460 - have a timeout on github jobs**
Test on [geo-unsup-mapper](https://github.com/MiraGeoscience/geo-unsup-mapper/actions/runs/10339866844)