### PR TITLE
DEVOPS-468: Modify which files are checked during the pre-commit

### DIFF
--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -5,11 +5,8 @@ on:
     inputs:
       app_name:
         description: 'Name of the app to run pre-commit on'
-        required: true
+        required: false
         type: string
-
-env:
-  source_dir: ${{inputs.app_name}}
 
 jobs:
   pre-commit:
@@ -26,10 +23,17 @@ jobs:
       - name: capture modified files
         if: ${{ github.event_name == 'pull_request' }}
         run: >-
-          git fetch --deepen=500 origin ${{github.base_ref}}
-          && echo "FILES_PARAM=$(
-          git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | grep -E "^(${source_dir}|tests)/.*\.py$" | xargs
-          )" >> $GITHUB_ENV
+          git fetch --deepen=500 origin ${{github.base_ref}} && 
+          if [ -n "${{ inputs.app_name}}"]; then
+            echo "FILES_PARAM=$(
+              git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | grep -E "^(${{ inputs.app_name }}|tests)/.*\.py$" | xargs
+            )" >> $GITHUB_ENV
+          else
+            echo "FILES_PARAM=$(
+              git diff --diff-filter=AM --name-only refs/remotes/origin/${{github.base_ref}}... -- | xargs
+            )" >> $GITHUB_ENV
+          fi
+          
       - name: Run pre-commit on modified files
         if: ${{ (github.event_name == 'pull_request') && (env.FILES_PARAM) }}
         uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
**DEVOPS-468 - in Analyst: use shared GitHub workflows and pre-commit hooks**
Since Insight, Integrator and GMS don't need to restrict verified files to those in the app_directory, I modify the workflow to integrate this feature without modifying each python project using this github workflow.