### PR TITLE
DEVOPS-483: Add a timeout_minutes input in all reusable workflows

### DIFF
--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -7,6 +7,11 @@ on:
         description: 'Name of the app to run pre-commit on'
         required: false
         type: string
+      timeout_minutes:
+        description: 'Timeout in minutes for the job'
+        required: false
+        type: number
+        default: 20
 
 jobs:
   pre-commit:
@@ -17,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP: pylint
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/reusable-python-publish_package.yml
+++ b/.github/workflows/reusable-python-publish_package.yml
@@ -37,6 +37,11 @@ on:
             description: 'List with all the names of repositories to publish on (eg. ["analyst-dev-pypi-local", "analyst-pypi-local"])'
             required: true
             type: string
+        timeout_minutes:
+            description: 'Timeout in minutes for the job'
+            required: false
+            type: number
+            default: 20
 
     secrets:
         EXTRA_PYPI_REPO_USER:
@@ -57,7 +62,7 @@ jobs:
     release_pypi_package:
         name: Release PyPI package
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: ${{ inputs.timeout_minutes }}
         if: ${{ inputs.package_manager != 'conda' }}
         env:
             cache_number: 1
@@ -123,7 +128,7 @@ jobs:
             PYTHONUTF8: 1
             CONDA_CHANNEL_PRIORITY: strict
             PIP_NO_DEPS: 1 # all dependencies are installed from conda
-        timeout-minutes: 20
+        timeout-minutes: ${{ inputs.timeout_minutes }}
         if: ${{ inputs.package_manager == 'conda' }}
         steps:
             -   name: Checkout

--- a/.github/workflows/reusable-python-pytest_unix_os.yml
+++ b/.github/workflows/reusable-python-pytest_unix_os.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      timeout_minutes:
+        description: 'Timeout in minutes for the job'
+        required: false
+        type: number
+        default: 20
 
     secrets:
       EXTRA_PYPI_REPO_USER:
@@ -55,7 +60,7 @@ jobs:
     defaults:
       run:
         shell: 'bash -l {0}'
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable-python-pytest_windows.yml
+++ b/.github/workflows/reusable-python-pytest_windows.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: false
+      timeout_minutes:
+        description: 'Timeout in minutes for the job'
+        required: false
+        type: number
+        default: 20
 
     secrets:
       CODECOV_TOKEN:
@@ -55,7 +60,7 @@ jobs:
     defaults:
       run:
         shell: 'bash -l {0}'
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      timeout_minutes:
+        description: 'Timeout in minutes for the job'
+        required: false
+        type: number
+        default: 20
     secrets:
       EXTRA_PYPI_REPO_USER:
         description: 'Extra PyPI repository username. Only used if `extra_repository` is True.'
@@ -41,10 +46,11 @@ jobs:
     defaults:
       run:
         shell: 'bash -l {0}'
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: ${{ inputs.lfs }}
           fetch-depth: 0
       - name: Set up Python version
         uses: actions/setup-python@v4


### PR DESCRIPTION
**DEVOPS-483 - Add an optionnal timeout in reusable github workflow**

⚠️ Test on [simpeg-drivers](https://github.com/MiraGeoscience/simpeg-drivers/actions/runs/10634048675)