### PR TITLE
DEVOPS-473: Add the possibility to choice the platform for the reusable github workflows

### DIFF
--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -16,7 +16,7 @@ on:
         description: 'Python version used with pre-commit'
         required: false
         type: string
-        default: '3.10'
+        default: "3.10"
       timeout_minutes:
         description: 'Timeout in minutes for the job'
         required: false

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: "['ubuntu-latest']"
+      python-version:
+        description: 'Python version used with pre-commit'
+        required: false
+        type: string
+        default: '3.10'
       timeout_minutes:
         description: 'Timeout in minutes for the job'
         required: false
@@ -33,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
       - name: capture modified files
         if: ${{ github.event_name == 'pull_request' }}
         run: >-

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -7,6 +7,11 @@ on:
         description: 'Name of the app to run pre-commit on'
         required: false
         type: string
+      os:
+        description: 'Matrix of OS to run against (eg. ["ubuntu-latest", "macos-latest"])'
+        required: false
+        type: string
+        default: "['ubuntu-latest']"
       timeout_minutes:
         description: 'Timeout in minutes for the job'
         required: false
@@ -19,7 +24,9 @@ jobs:
     if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.draft == false) }}
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+      matrix:
+        os: ${{ fromJson(inputs.os) }}
+    runs-on: ${{ matrix.os }}
     env:
       SKIP: pylint
     timeout-minutes: ${{ inputs.timeout_minutes }}

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: number
         default: 20
+      os:
+        description: 'Matrix of OS to test against (eg. ["ubuntu-latest", "macos-latest"])'
+        required: false
+        type: string
+        default: "['ubuntu-latest']"
     secrets:
       EXTRA_PYPI_REPO_USER:
         description: 'Extra PyPI repository username. Only used if `extra_repository` is True.'
@@ -42,7 +47,10 @@ jobs:
   pylint:
     name: pylint
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.os) }}
+    runs-on: ${{ matrix. os}}
     defaults:
       run:
         shell: 'bash -l {0}'


### PR DESCRIPTION
**DEVOPS-473**

With pre-commit and static-analysis workflows, we need an option to choose which platform (windows, linux or macOS) we want to run our workflows on.

I choice to use the new version of our nomenclature (```lower-case```). This nomenclature is used in DEVOPS-466 and will be deploy on every workflow at the end of the week.

⚠️ Test on [geoh5py](https://github.com/MiraGeoscience/geoh5py/actions/runs/11019567479)