### PR TITLE
DEVOPS-552: Update pypi url

### DIFF
--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -120,5 +120,5 @@ jobs:
                 with:
                     verbose: true
                     packages-dir: ${{ env.build-dir-path }}/
-                    repository-url: https://${{ matrix.virtual-repo-name == 'test-pypi' && 'test.pypi' || 'pypi'}}.org/legacy/
+                    repository-url: https://upload.${{ matrix.virtual-repo-name == 'test-pypi' && 'test.pypi' || 'pypi'}}.org/legacy/
                     password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
**DEVOPS-552 - Correct Pypi url in reusable-python-publish_pip_package.yml**
