### PR TITLE
DEVOPS-553: Add a output build-path inside Build conda package step

### DIFF
--- a/.github/workflows/reusable-python-publish_conda_package.yml
+++ b/.github/workflows/reusable-python-publish_conda_package.yml
@@ -118,6 +118,7 @@ jobs:
                         echo "No build at ${BUILD_PATH}"
                         exit 1
                     fi
+                    echo "build-path=${BUILD_PATH}" >> $GITHUB_OUTPUT
                     echo "build-dir-path=$(dirname ${BUILD_PATH})" >> $GITHUB_OUTPUT
             
             -   name: Archive build artifact


### PR DESCRIPTION
**DEVOPS-553 - Correct build path in reusable-python-publish_conda_package**
