### PR TITLE
DEVOPS-552: Disable fail-fast option in the publishing job

### DIFF
--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -86,6 +86,7 @@ jobs:
         needs: [ build_poetry_package, build_setuptools_package ]
         if: ${{ always() && contains(needs.*.result, 'success') && !contains(needs.*.result, 'failure') }}
         strategy:
+            fail-fast: false
             matrix:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:


### PR DESCRIPTION
**DEVOPS-552 - Correct Pypi url in reusable-python-publish_pip_package.yml**
