### PR TITLE
DEVOPS-671: collect the conda.lock files that do not specify channels

### DIFF
--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -129,8 +129,9 @@ stages:
                 $conda_channels = ""
                 $i = 0
                 foreach ($repo in $array) {
-                  echo "Adding repository ${repo}-conda-${{ parameters.environment }}"
-                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo}-conda-${{ parameters.environment }}-local"
+                  $repo_name = "${repo}-conda-${{ parameters.environment }}-local"
+                  echo "Adding repository '${repo_name}'"
+                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
                   micromamba config append channels $url
                   $conda_channels += $url
                   if (($array.Length - $i) -gt 1) {
@@ -138,8 +139,12 @@ stages:
                   }
                     $i++
                 }
-                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/conda-pytorch-${{ parameters.environment }}-remote"
-                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/conda-forge-${{ parameters.environment }}-remote"
+                $pytorch_repo_name = "conda-pytorch-${{ parameters.environment }}-remote"
+                echo "Adding repository '${pytorch_repo_name}'"
+                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${pytorch_repo_name}"
+                $conda_forge_repo_name = "conda-forge-${{ parameters.environment }}-remote"
+                echo "Adding repository '${conda_forge_repo_name}'"
+                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${conda_forge_repo_name}"
                 echo "##vso[task.setvariable variable=conda_channels;issecret=true]$conda_channels"
           - task: PowerShell@2
             name: ConfigurePyPISources

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -14,13 +14,19 @@ parameters:
       all:
         - geology
         - geophysics
+        - public
       all_deps_only:
+        - public
+      geology:
         - geology
+        - public
+      geophysics:
         - geophysics
-      geology: geology
-      geophysics: geophysics
+        - public
       interop: public
-      simpeg: geophysics
+      simpeg:
+        - geophysics
+        - public
 
 stages:
   - stage: TestInstallationOnMinimalCondaEnv

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -8,25 +8,35 @@ parameters:
       - prod
       - dev
   # Maps environment names to the repositories required for each environment.
-  - name: envToRepo
+  - name: envToLocalRepos
+    type: object
+    default:
+      all: geoplus
+      all_deps_only: ""
+      geology: geology
+      geophysics: geophysics
+      interop: public
+      simpeg: geophysics
+  - name: envToRemoteRepos
     type: object
     default:
       all:
-        - geology
-        - geophysics
-        - public
+        - pytorch
+        - conda-forge
       all_deps_only:
-        - public
+        - pytorch
+        - conda-forge
       geology:
-        - geology
-        - public
+        - pytorch
+        - conda-forge
       geophysics:
-        - geophysics
-        - public
-      interop: public
+        - pytorch
+        - conda-forge
+      interop:
+        - pytorch
+        - conda-forge
       simpeg:
-        - geophysics
-        - public
+        - conda-forge
 
 stages:
   - stage: TestInstallationOnMinimalCondaEnv
@@ -56,12 +66,13 @@ stages:
                     exit 1
                 fi
 
-                envToRepoJson='${{ convertToJson(parameters.envToRepo) }}'
+                envToLocalReposJson='${{ convertToJson(parameters.envToLocalRepos) }}'
+                envToRemoteReposJson='${{ convertToJson(parameters.envToRemoteRepos) }}'
 
                 # Initialize the matrix JSON
                 matrix="{}"
 
-                # Iterate through each key-value pair in envToRepo
+                # Iterate through each key-value pair in envToLocalRepos
                 while read -r entry; do
                   key=$(echo "$entry" | jq -r '.key')
                   value=$(echo "$entry" | jq -r '.value')
@@ -81,19 +92,23 @@ stages:
                     repos=$value
                   fi
 
+                  # also add repos from envToRemoteRepos for the current key
+                  remoteRepos=$(echo "$envToRemoteReposJson" | jq -r ".$key | join(\" \")")
+
                   # Create object
                   object_string=$( jq -n \
                                     --arg envType "$key" \
                                     --arg filename "$filename" \
                                     --arg repositories "$repos" \
-                                    '{ ($envType): {name: $envType, filename: $filename, repositories: $repositories }}' )
+                                    --arg remotes "$remoteRepos" \
+                                    '{ ($envType): {name: $envType, filename: $filename, repositories: $repositories, remotes: $remotes }}' )
 
                   # Merge with the main json_obj
                   matrix=$(echo "$matrix" | jq ". + $object_string")
 
                   # Copy matching files to the artifact folder
                   cp "$matchingFile" "$artifactFolder/"
-                done < <(echo "$envToRepoJson" | jq -c 'to_entries[]')
+                done < <(echo "$envToLocalReposJson" | jq -c 'to_entries[]')
 
                 json_matrix=$(echo $matrix | jq -c .)
 
@@ -124,11 +139,11 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                $string = "$(repositories)"
-                $array = $string.Split(" ")
+                $local_repos = "$(repositories)".Split(" ")
+                $remote_repos = "$(remotes)".Split(" ")
                 $conda_channels = ""
-                foreach ($repo in $array) {
-                  $repo_name = "${repo}-conda-${{ parameters.environment }}-local"
+                foreach ($repo in $local_repos) {
+                  $repo_name = "${repo}-noremote-conda-${{ parameters.environment }}-local"
                   echo "Adding Conda channel for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
                   micromamba config append channels $url
@@ -137,12 +152,11 @@ stages:
                   }
                   $conda_channels += $url
                 }
-                $pytorch_channel_name = "pytorch"
-                echo "Adding Conda channel for '${pytorch_channel_name}'"
-                $conda_channels += ",${pytorch_channel_name}"
-                $conda_forge_channel_name = "conda-forge"
-                echo "Adding Conda channel for '${conda_forge_channel_name}'"
-                $conda_channels += ",${conda_forge_channel_name}"
+
+                # join remote repos with ','
+                $remote_repos = $remote_repos -join ","
+                echo "Adding Conda channels: '${remote_repos}'"
+                $conda_channels += ",${remote_repos}"
                 echo "##vso[task.setvariable variable=conda_channels;issecret=true]$conda_channels"
           - task: PowerShell@2
             name: ConfigurePyPISources

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -166,7 +166,7 @@ stages:
                     $extra_index_url += " https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
                   }
                 }
-                $pypi_remote_name = "pypi-remote"
+                $pypi_remote_name = "pypi-${{ parameters.environment }}-remote"
                 echo "Adding repository '${pypi_remote_name}'"
                 $extra_index_url += " https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${pypi_remote_name}/simple"
                 $extra_index_url = $extra_index_url.Trim()

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -198,5 +198,11 @@ stages:
                 $Env:PIP_NO_DEPS = 1
                 cd $(Pipeline.Workspace)/envFiles
                 micromamba env create -y -f $(filename) -n $(name)
-                micromamba run -n $(name) python -c "import geoh5py; print(f'geoh5py version: {geoh5py.__version__}')"
-                micromamba run -n $(name) python -c "import numpy; print(f'numpy version: {numpy.__version__}')"
+          - task: PowerShell@2
+            name: CheckEnvironment
+            displayName: Check environment
+            inputs:
+              targetType: 'inline'
+            script: |
+              micromamba run -n $(name) python -c "import geoh5py; print(f'geoh5py version: {geoh5py.__version__}')"
+              micromamba run -n $(name) python -c "import numpy; print(f'numpy version: {numpy.__version__}')"

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -198,3 +198,5 @@ stages:
                 $Env:PIP_NO_DEPS = 1
                 cd $(Pipeline.Workspace)/envFiles
                 micromamba env create -y -f $(filename) -n $(name)
+                micromamba run -n $(name) python -c "import geoh5py; print(f'geoh5py version: {geoh5py.__version__}')"
+                micromamba run -n $(name) python -c "import numpy; print(f'numpy version: {numpy.__version__}')"

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -8,7 +8,7 @@ parameters:
       - prod
       - dev
   # Maps environment names to the repositories required for each environment.
-  - name: envToLocalRepos
+  - name: envToVirtualRepos
     type: object
     default:
       all: geoplus
@@ -66,13 +66,13 @@ stages:
                     exit 1
                 fi
 
-                envToLocalReposJson='${{ convertToJson(parameters.envToLocalRepos) }}'
+                envToVirtualReposJson='${{ convertToJson(parameters.envToVirtualRepos) }}'
                 envToRemoteReposJson='${{ convertToJson(parameters.envToRemoteRepos) }}'
 
                 # Initialize the matrix JSON
                 matrix="{}"
 
-                # Iterate through each key-value pair in envToLocalRepos
+                # Iterate through each key-value pair in envToVirtualRepos
                 while read -r entry; do
                   key=$(echo "$entry" | jq -r '.key')
                   value=$(echo "$entry" | jq -r '.value')
@@ -108,7 +108,7 @@ stages:
 
                   # Copy matching files to the artifact folder
                   cp "$matchingFile" "$artifactFolder/"
-                done < <(echo "$envToLocalReposJson" | jq -c 'to_entries[]')
+                done < <(echo "$envToVirtualReposJson" | jq -c 'to_entries[]')
 
                 json_matrix=$(echo $matrix | jq -c .)
 
@@ -139,11 +139,11 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                $local_repos = "$(repositories)".Split(" ")
+                $virtual_repos = "$(repositories)".Split(" ")
                 $remote_repos = "$(remotes)".Split(" ")
                 $conda_channels = ""
-                foreach ($repo in $local_repos) {
-                  $repo_name = "${repo}-noremote-conda-${{ parameters.environment }}-local"
+                foreach ($repo in $virtual_repos) {
+                  $repo_name = "${repo}-noremote-conda-${{ parameters.environment }}"
                   echo "Adding Conda channel for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
                   if ($conda_channels -ne "") {
@@ -168,7 +168,7 @@ stages:
                 $pip_index_url = ""
                 $pip_extra_index_url = ""
                 foreach ($repo in $array) {
-                  $repo_name = "${repo}-pypi-${{ parameters.environment }}-local"
+                  $repo_name = "${repo}-pypi-${{ parameters.environment }}"
                   echo "Adding Pip index URL for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
                   if ($pip_index_url -eq "") {

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -37,16 +37,16 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                envFolder="environments"
+                buildEnvFolder="build"
                 artifactFolder="artifact_envFiles"
 
                 # Create test directories and files
-                mkdir -p "$envFolder" "$artifactFolder"
+                mkdir -p "environments" "$artifactFolder"
 
                 # DiscoverFiles
-                files=$(find $envFolder -name "py-3.10-win-64-*.yml")
+                files=$(find $buildEnvFolder -name "py-3.10-win-64-*.yml")
                 if [[ -z "$files" ]]; then
-                    echo "No win-64 environment files found in $envFolder"
+                    echo "No win-64 environment files found in $buildEnvFolder"
                     exit 1
                 fi
 
@@ -60,7 +60,7 @@ stages:
                   key=$(echo "$entry" | jq -r '.key')
                   value=$(echo "$entry" | jq -r '.value')
                   # Find the corresponding file
-                  matchingFile=$(echo "$files" | grep -m 1 "$key")
+                  matchingFile=$(echo "$files" | grep -m 1 "$key\.conda\.lock")
 
                   if [ -z "$matchingFile" ]; then
                     echo "No matching file found for $key, skipping..."

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -192,6 +192,7 @@ stages:
               script: |
                 $Env:CONDA_CHANNELS = "$(conda_channels)"
                 $Env:CONDARC = "$(Pipeline.Workspace)/envFiles"
+                $Env:MAMBA_CHANNEL_PRIORITY = "strict"
                 $Env:PIP_INDEX_URL = "$(pip_index_url)"
                 $Env:PIP_EXTRA_INDEX_URL = "$(pip_extra_index_url)"
                 $Env:PIP_NO_DEPS = 1

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -124,7 +124,7 @@ stages:
                 $i = 0
                 foreach ($repo in $array) {
                   echo "Adding repository ${repo}-conda-${{ parameters.environment }}"
-                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo}-conda-${{ parameters.environment }}"
+                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo}-conda-${{ parameters.environment }}-local"
                   micromamba config append channels $url
                   $conda_channels += $url
                   if (($array.Length - $i) -gt 1) {
@@ -132,6 +132,8 @@ stages:
                   }
                     $i++
                 }
+                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/conda-pytorch-${{ parameters.environment }}-remote"
+                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/conda-forge-${{ parameters.environment }}-remote"
                 echo "##vso[task.setvariable variable=conda_channels;issecret=true]$conda_channels"
           - task: PowerShell@2
             name: ConfigurePyPISources
@@ -146,7 +148,7 @@ stages:
                 $i = 0
                 foreach ($repo in $array) {
                   echo "Adding repository ${repo}-pypi-${{ parameters.environment }}"
-                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo}-pypi-${{ parameters.environment }}/simple"
+                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo}-pypi-${{ parameters.environment }}-local/simple"
                   if ($i -eq 0) {
                     $index_url = $url
                   } else {

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -139,21 +139,21 @@ stages:
             inputs:
               targetType: 'inline'
               script: |
-                $virtual_repos = "$(repositories)".Split(" ")
-                $remote_repos = "$(remotes)".Split(" ")
                 $conda_channels = ""
-                foreach ($repo in $virtual_repos) {
-                  $repo_name = "${repo}-noremote-conda-${{ parameters.environment }}"
-                  echo "Adding Conda channel for '${repo_name}'"
-                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
-                  if ($conda_channels) {
-                    $conda_channels += ","
+                if ($repositories) {
+                  $virtual_repos = "$(repositories)".Split(" ")
+                  foreach ($repo in $virtual_repos) {
+                    $repo_name = "${repo}-noremote-conda-${{ parameters.environment }}"
+                    echo "Adding Conda channel for '${repo_name}'"
+                    $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
+                    if ($conda_channels) {
+                      $conda_channels += ","
+                    }
+                    $conda_channels += $url
                   }
-                  $conda_channels += $url
                 }
 
-                # join remote repos with ','
-                $remote_repos = $remote_repos -join ","
+                $remote_repos = "$(remotes)".Split(" ") -join ","
                 echo "Adding Conda channels: '${remote_repos}'"
                 if ($conda_channels -and $remote_repos) {
                   $conda_channels += ","

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -151,20 +151,20 @@ stages:
                 $array = $string.Split(" ")
                 $index_url = ""
                 $extra_index_url = ""
-                $i = 0
                 foreach ($repo in $array) {
-                  echo "Adding repository ${repo}-pypi-${{ parameters.environment }}"
-                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo}-pypi-${{ parameters.environment }}-local/simple"
-                  if ($i -eq 0) {
-                    $index_url = $url
-                  } else {
-                    $extra_index_url += $url
-                    if (($array.Length - $i) -gt 1) {
-                      $extra_index_url += " "
-                    }
+                  $repo_name = "${repo}-pypi-${{ parameters.environment }}-local"
+                  echo "Adding repository '${repo_name}'"
+                  if ($index_url -eq "") {
+                    $index_url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
                   }
-                  $i++
+                  else {
+                    $extra_index_url += " https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
+                  }
                 }
+                $pypi_remote_name = "pypi-remote"
+                echo "Adding repository '${pypi_remote_name}'"
+                $extra_index_url += " https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${pypi_remote_name}/simple"
+                $extra_index_url = $extra_index_url.Trim()
                 echo "##vso[task.setvariable variable=extra_index_url;issecret=true]$extra_index_url"
                 echo "##vso[task.setvariable variable=index_url;issecret=true]$index_url"
           - task: PowerShell@2

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -156,7 +156,7 @@ stages:
                 $pip_extra_index_url = ""
                 foreach ($repo in $array) {
                   $repo_name = "${repo}-pypi-${{ parameters.environment }}-local"
-                  echo "Adding Pip index for '${repo_name}'"
+                  echo "Adding Pip index URL for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
                   if ($pip_index_url -eq "") {
                     $pip_index_url = $url
@@ -165,9 +165,9 @@ stages:
                     $pip_extra_index_url += " $url"
                   }
                 }
-                $pypi_index_name = "pypi"
-                echo "Adding Pip index for '${pypi_index_name}'"
-                $pip_extra_index_url += " https://pypi.org/simple"
+                $pypi_repo_name = "pypi-${{ parameters.environment }}-remote"
+                echo "Adding Pip index URL for '${pypi_repo_name}'"
+                $pip_extra_index_url += " https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
                 $pip_extra_index_url = $pip_extra_index_url.Trim()
                 echo "##vso[task.setvariable variable=pip_index_url;issecret=true]$pip_index_url"
                 echo "##vso[task.setvariable variable=pip_extra_index_url;issecret=true]$pip_extra_index_url"

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -146,7 +146,6 @@ stages:
                   $repo_name = "${repo}-noremote-conda-${{ parameters.environment }}-local"
                   echo "Adding Conda channel for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
-                  micromamba config append channels $url
                   if ($conda_channels -ne "") {
                     $conda_channels += ","
                   }

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -155,7 +155,10 @@ stages:
                 # join remote repos with ','
                 $remote_repos = $remote_repos -join ","
                 echo "Adding Conda channels: '${remote_repos}'"
-                $conda_channels += ",${remote_repos}"
+                if ($conda_channels -and $remote_repos) {
+                  $conda_channels += ","
+                }
+                $conda_channels += "${remote_repos}"
                 echo "##vso[task.setvariable variable=conda_channels;issecret=true]$conda_channels"
           - task: PowerShell@2
             name: ConfigurePyPISources

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -191,8 +191,8 @@ stages:
               targetType: 'inline'
               script: |
                 $Env:CONDA_CHANNELS = "$(conda_channels)"
-                $Env:CONDARC = "$(Pipeline.Workspace)/envFiles"
                 $Env:MAMBA_CHANNEL_PRIORITY = "strict"
+                $Env:CONDARC = "$(Pipeline.Workspace)/envFiles"  # point to a non-existent .condarc
                 $Env:PIP_INDEX_URL = "$(pip_index_url)"
                 $Env:PIP_EXTRA_INDEX_URL = "$(pip_extra_index_url)"
                 $Env:PIP_NO_DEPS = 1

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -127,24 +127,22 @@ stages:
                 $string = "$(repositories)"
                 $array = $string.Split(" ")
                 $conda_channels = ""
-                $i = 0
                 foreach ($repo in $array) {
                   $repo_name = "${repo}-conda-${{ parameters.environment }}-local"
-                  echo "Adding repository '${repo_name}'"
+                  echo "Adding Conda channel for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
                   micromamba config append channels $url
-                  $conda_channels += $url
-                  if (($array.Length - $i) -gt 1) {
+                  if ($conda_channels -ne "") {
                     $conda_channels += ","
                   }
-                    $i++
+                  $conda_channels += $url
                 }
-                $pytorch_repo_name = "conda-pytorch-${{ parameters.environment }}-remote"
-                echo "Adding repository '${pytorch_repo_name}'"
-                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${pytorch_repo_name}"
-                $conda_forge_repo_name = "conda-forge-${{ parameters.environment }}-remote"
-                echo "Adding repository '${conda_forge_repo_name}'"
-                $conda_channels += ",https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${conda_forge_repo_name}"
+                $pytorch_channel_name = "pytorch"
+                echo "Adding Conda channel for '${pytorch_channel_name}'"
+                $conda_channels += ",${pytorch_channel_name}"
+                $conda_forge_channel_name = "conda-forge"
+                echo "Adding Conda channel for '${conda_forge_channel_name}'"
+                $conda_channels += ",${conda_forge_channel_name}"
                 echo "##vso[task.setvariable variable=conda_channels;issecret=true]$conda_channels"
           - task: PowerShell@2
             name: ConfigurePyPISources
@@ -154,24 +152,25 @@ stages:
               script: |
                 $string = "$(repositories)"
                 $array = $string.Split(" ")
-                $index_url = ""
-                $extra_index_url = ""
+                $pip_index_url = ""
+                $pip_extra_index_url = ""
                 foreach ($repo in $array) {
                   $repo_name = "${repo}-pypi-${{ parameters.environment }}-local"
-                  echo "Adding repository '${repo_name}'"
-                  if ($index_url -eq "") {
-                    $index_url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
+                  echo "Adding Pip index for '${repo_name}'"
+                  $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
+                  if ($pip_index_url -eq "") {
+                    $pip_index_url = $url
                   }
                   else {
-                    $extra_index_url += " https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
+                    $pip_extra_index_url += " $url"
                   }
                 }
-                $pypi_remote_name = "pypi-${{ parameters.environment }}-remote"
-                echo "Adding repository '${pypi_remote_name}'"
-                $extra_index_url += " https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${pypi_remote_name}/simple"
-                $extra_index_url = $extra_index_url.Trim()
-                echo "##vso[task.setvariable variable=extra_index_url;issecret=true]$extra_index_url"
-                echo "##vso[task.setvariable variable=index_url;issecret=true]$index_url"
+                $pypi_index_name = "pypi"
+                echo "Adding Pip index for '${pypi_index_name}'"
+                $pip_extra_index_url += " https://pypi.org/simple"
+                $pip_extra_index_url = $pip_extra_index_url.Trim()
+                echo "##vso[task.setvariable variable=pip_index_url;issecret=true]$pip_index_url"
+                echo "##vso[task.setvariable variable=pip_extra_index_url;issecret=true]$pip_extra_index_url"
           - task: PowerShell@2
             name: InstallEnvironment
             displayName: Install environment
@@ -180,8 +179,8 @@ stages:
               script: |
                 $Env:CONDA_CHANNELS = "$(conda_channels)"
                 $Env:CONDARC = "$(Pipeline.Workspace)/envFiles"
-                $Env:PIP_INDEX_URL = "$(index_url)"
-                $Env:PIP_EXTRA_INDEX_URL = "$(extra_index_url)"
+                $Env:PIP_INDEX_URL = "$(pip_index_url)"
+                $Env:PIP_EXTRA_INDEX_URL = "$(pip_extra_index_url)"
                 $Env:PIP_NO_DEPS = 1
                 cd $(Pipeline.Workspace)/envFiles
                 micromamba env create -y -f $(filename) -n $(name)

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -192,17 +192,16 @@ stages:
               script: |
                 $Env:CONDA_CHANNELS = "$(conda_channels)"
                 $Env:MAMBA_CHANNEL_PRIORITY = "strict"
-                $Env:CONDARC = "$(Pipeline.Workspace)/envFiles"  # point to a non-existent .condarc
                 $Env:PIP_INDEX_URL = "$(pip_index_url)"
                 $Env:PIP_EXTRA_INDEX_URL = "$(pip_extra_index_url)"
                 $Env:PIP_NO_DEPS = 1
                 cd $(Pipeline.Workspace)/envFiles
-                micromamba env create -y -f $(filename) -n $(name)
+                micromamba --no-rc env create -y -f $(filename) -n $(name)
           - task: PowerShell@2
             name: CheckEnvironment
             displayName: Check environment
             inputs:
               targetType: 'inline'
-            script: |
-              micromamba run -n $(name) python -c "import geoh5py; print(f'geoh5py version: {geoh5py.__version__}')"
-              micromamba run -n $(name) python -c "import numpy; print(f'numpy version: {numpy.__version__}')"
+              script: |
+                micromamba --no-rc run -n $(name) python -c "import geoh5py; print(f'geoh5py version: {geoh5py.__version__}')"
+                micromamba --no-rc run -n $(name) python -c "import numpy; print(f'numpy version: {numpy.__version__}')"

--- a/.azure-pipelines/template-test-minimal-conda-env-install.yml
+++ b/.azure-pipelines/template-test-minimal-conda-env-install.yml
@@ -146,7 +146,7 @@ stages:
                   $repo_name = "${repo}-noremote-conda-${{ parameters.environment }}"
                   echo "Adding Conda channel for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/conda/${repo_name}"
-                  if ($conda_channels -ne "") {
+                  if ($conda_channels) {
                     $conda_channels += ","
                   }
                   $conda_channels += $url
@@ -174,11 +174,11 @@ stages:
                   $repo_name = "${repo}-pypi-${{ parameters.environment }}"
                   echo "Adding Pip index URL for '${repo_name}'"
                   $url = "https://$(JFROG_ARTIFACTORY_USER):$(JFROG_ARTIFACTORY_TOKEN)@$(JFROG_ARTIFACTORY_URL)/pypi/${repo_name}/simple"
-                  if ($pip_index_url -eq "") {
-                    $pip_index_url = $url
+                  if ($pip_index_url) {
+                    $pip_extra_index_url += " $url"
                   }
                   else {
-                    $pip_extra_index_url += " $url"
+                    $pip_index_url = $url
                   }
                 }
                 $pypi_repo_name = "pypi-${{ parameters.environment }}-remote"


### PR DESCRIPTION
**DEVOPS-671 - test installation on Azure clean machine is not using artifactory channels**

testing from https://github.com/MiraGeoscience/geopy-distrib/commits/DEVOPS-671/