### PR TITLE
DEVOPS-634: fix pre commit run on push

### DIFF
--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -62,8 +62,6 @@ jobs:
         if: ${{ (github.event_name == 'pull_request') }}
         run: |
           git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
-      - run: git fetch --deepen=500 origin ${{github.base_ref}}
-        if: ${{ (github.event_name != 'pull_request') }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -53,11 +53,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
-      # for non PR events, check out to depth 1
+      # for non PR events, check out to default depth (i.e. 1)
       - uses: actions/checkout@v4
         if: ${{ (github.event_name != 'pull_request') }}
-        with:
-          fetch-depth: 1
       - name: Fetch target branch
         if: ${{ (github.event_name == 'pull_request') }}
         run: |

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ steps.base-depth.outputs.base-depth }}
+      # for non PR events, check out to depth 1
+      - uses: actions/checkout@v4
+        if: ${{ (github.event_name != 'pull_request') }}
+        with:
+          fetch-depth: 1
       - name: Fetch target branch
         if: ${{ (github.event_name == 'pull_request') }}
         run: |


### PR DESCRIPTION
**DEVOPS-634 - pre-commit in github action sometimes fails to get base ref**
Fix the reusable pre-commit action so that it works on branch pushes as well as PRs.