### PR TITLE
DEVOPS-784: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,8 @@
 name: pre-commit
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
**DEVOPS-784 - address security issues reported on CI-Tools pipelines**
Potential fix for [https://github.com/MiraGeoscience/CI-tools/security/code-scanning/3](https://github.com/MiraGeoscience/CI-tools/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since this is a pre-commit workflow, it likely only needs `contents: read` permissions to access repository contents. If additional permissions are required for the reusable workflow, they should be added explicitly based on its functionality.

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden. This ensures that the `GITHUB_TOKEN` has the least privileges necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._