### PR TITLE
DEVOPS-784: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-pr_add_jira_summary.yml
+++ b/.github/workflows/jira-pr_add_jira_summary.yml
@@ -1,5 +1,9 @@
 name: Add JIRA issue summary
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types: [opened]


### PR DESCRIPTION
**DEVOPS-784 - address security issues reported on CI-Tools pipelines**
Potential fix for [https://github.com/MiraGeoscience/CI-tools/security/code-scanning/1](https://github.com/MiraGeoscience/CI-tools/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the context, the workflow likely interacts with pull requests and possibly repository contents. Therefore, we will set `contents: read` and `pull-requests: write` as the permissions. If additional permissions are required, they can be added later after verifying the workflow's requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._