### PR TITLE
DEVOPS-784: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jira-issue_to_jira.yml
+++ b/.github/workflows/jira-issue_to_jira.yml
@@ -1,5 +1,8 @@
 name: Create JIRA issue
 
+permissions:
+  issues: write
+
 on:
   issues:
     types: [opened]


### PR DESCRIPTION
**DEVOPS-784 - address security issues reported on CI-Tools pipelines**
Potential fix for [https://github.com/MiraGeoscience/CI-tools/security/code-scanning/2](https://github.com/MiraGeoscience/CI-tools/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with JIRA issues, it likely requires `issues: write` permission. Other permissions should be set to `read` or omitted entirely if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._