### PR TITLE
DEVOPS-822: do not run pylint on all files in scope of a PullRequest

### DIFF
--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -113,6 +113,7 @@ jobs:
           fi
 
       - name: Run Pylint on all files
+        if: ${{ github.event_name == 'push' }}
         run: |
           if ${{ inputs.package-manager == 'conda' }}; then
             pylint $source_dir tests


### PR DESCRIPTION
**DEVOPS-822 - pylint runs twice on in PR, on modified files and then on all files**
