### PR TITLE
DEVOPS-990: changing the Remove git credentials to fix the bump from 5 to 6. 

### DIFF
--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -66,8 +66,8 @@ jobs:
         run: git fetch origin ${BASE_REF}:${BASE_REF}
       - name: Remove git credentials
         run: |
-          git config --local --unset-all http.https://github.com/.extraheader; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
-          git config --local --unset-all include.path; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
+          git config --local --unset-all http.https://github.com/.extraheader || [ $? -eq 5 ]
+          git config --local --unset-all include.path || [ $? -eq 5 ]
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -53,7 +53,7 @@ jobs:
           depth=$(expr ${{ github.event.pull_request.commits }} + 1)
           echo "base-depth=$depth"
           echo "base-depth=$depth" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           lfs: ${{ inputs.lfs }}
           # for non PR events, check out to depth 1 (the default)
@@ -65,7 +65,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch origin ${BASE_REF}:${BASE_REF}
       - name: Remove git credentials
-        run: git config --unset-all http.https://github.com/.extraheader
+        run: git config --local --unset-all include.path 
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -65,7 +65,9 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch origin ${BASE_REF}:${BASE_REF}
       - name: Remove git credentials
-        run: git config --local --unset-all include.path 
+        run: |
+          git config --local --unset-all http.https://github.com/.extraheader; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
+          git config --local --unset-all include.path; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -65,6 +65,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: git fetch origin ${BASE_REF}:${BASE_REF}
       - name: Remove git credentials
+        shell: bash
         run: |
           git config --local --unset-all http.https://github.com/.extraheader || [ $? -eq 5 ]
           git config --local --unset-all include.path || [ $? -eq 5 ]

--- a/.github/workflows/reusable-python-build_poetry_package.yml
+++ b/.github/workflows/reusable-python-build_poetry_package.yml
@@ -66,7 +66,7 @@ jobs:
             version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@v6
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0

--- a/.github/workflows/reusable-python-build_setuptools_package.yml
+++ b/.github/workflows/reusable-python-build_setuptools_package.yml
@@ -61,7 +61,7 @@ jobs:
             version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@v6
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -80,7 +80,7 @@ jobs:
         timeout-minutes: ${{ inputs.timeout-minutes }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v5
+                uses: actions/checkout@v6
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -83,7 +83,7 @@ jobs:
         shell: 'bash -l {0}'
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           lfs: ${{ inputs.lfs }}
           fetch-depth: 0

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Remove git credentials
         run: |
-          git config --local --unset-all http.https://github.com/.extraheader; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
-          git config --local --unset-all include.path; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
+          git config --local --unset-all http.https://github.com/.extraheader || [ $? -eq 5 ]
+          git config --local --unset-all include.path || [ $? -eq 5 ]
 
       - name: Set up Python version
         uses: actions/setup-python@v6

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -86,6 +86,7 @@ jobs:
           )" >> $GITHUB_ENV
 
       - name: Remove git credentials
+        shell: bash
         run: |
           git config --local --unset-all http.https://github.com/.extraheader || [ $? -eq 5 ]
           git config --local --unset-all include.path || [ $? -eq 5 ]

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -86,7 +86,9 @@ jobs:
           )" >> $GITHUB_ENV
 
       - name: Remove git credentials
-        run: git config --local --unset-all include.path
+        run: |
+          git config --local --unset-all http.https://github.com/.extraheader; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
+          git config --local --unset-all include.path; rc=$?; [ $rc -eq 0 ] || [ $rc -eq 5 ] || exit $rc
 
       - name: Set up Python version
         uses: actions/setup-python@v6

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -71,7 +71,7 @@ jobs:
         shell: 'bash -l {0}'
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           lfs: ${{ inputs.lfs }}
           fetch-depth: 0
@@ -86,7 +86,7 @@ jobs:
           )" >> $GITHUB_ENV
 
       - name: Remove git credentials
-        run: git config --unset-all http.https://github.com/.extraheader
+        run: git config --local --unset-all include.path
 
       - name: Set up Python version
         uses: actions/setup-python@v6

--- a/.github/workflows/reusable-zizmor-advanced-security.yml
+++ b/.github/workflows/reusable-zizmor-advanced-security.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/reusable-zizmor-annotate.yml
+++ b/.github/workflows/reusable-zizmor-annotate.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/reusable-zizmor-security.yml
+++ b/.github/workflows/reusable-zizmor-security.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 


### PR DESCRIPTION
**DEVOPS-990 - "Remove git credentials" step failing with exit code 5 after upgrading to actions/checkout@v6**

Changes
Updated reusable-pre_commit.yml and reusable-python-static_analysis.yml
Now attempts to unset both credential keys to handle either checkout version
Uses || [ $? -eq 5 ] to gracefully handle the "key not found" case while still failing on any other error (e.g. permission issues), preserving the security guarantee that credentials are confirmed removed before subsequent steps run
Security.

Ignoring exit code 5 is safe: it means the key was never present, so no credentials exist to leak. Any other failure (real removal error) still causes the pipeline to stop