### PR TITLE
DEVOPS-1066: regroup dependabot for actions into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
     target-branch: "main"
     cooldown:
       default-days: 4
+    groups:
+      github-actions:
+        patterns:
+          - actions/*
+      mirageo-ci-tools:
+        patterns:
+          - MiraGeoscience/CI-tools/.github/actions/*
+          - MiraGeoscience/CI-tools/.github/workflows/*


### PR DESCRIPTION
**DEVOPS-1066 - use CI-tools v3 in all the repos**
- one PR for all github actions
- one PR for all MiraGeoscience/CI-tools actions