### PR TITLE
DEVOPS-1066: point to ci-tools@v3

### DIFF
--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -132,7 +132,7 @@ jobs:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ env.build-dir-path }}
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: ${{ env.build-dir-path }}
@@ -158,7 +158,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -66,7 +66,7 @@ jobs:
     build_poetry_package:
         name: Build poetry package
         if: ${{ inputs.package-manager == 'poetry' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@main
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3
         with:
             package-name: ${{ inputs.package-name }}
             source-path: ${{ inputs.source-path || '.' }}
@@ -83,7 +83,7 @@ jobs:
     build_setuptools_package:
         name: Build setuptools package
         if: ${{ inputs.package-manager == 'setuptools' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@main
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3
         with:
             package-name: ${{ inputs.package-name }}
             python-version: ${{ inputs.python-version }}

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -178,7 +178,7 @@ jobs:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: build-dir
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
                 with:
                     build-dir-path: build-dir/noarch
                     artifactory-dir-path: ${{ matrix.publish-repo-name}}/noarch
@@ -194,7 +194,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3
         name: Setup conda env
         if: ${{ inputs.package-manager == 'conda' }}
         env:
@@ -107,7 +107,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -117,14 +117,14 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
           cache-number: ${{ inputs.cache-number }}
           runner-os: ${{ runner.os }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:

--- a/.github/workflows/reusable-python-release_conda_assets.yml
+++ b/.github/workflows/reusable-python-release_conda_assets.yml
@@ -39,7 +39,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.conda'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
                 with:
                     build-dir-path: download-assets
                     artifactory-dir-path: ${{ matrix.virtual-repo-name}}/noarch

--- a/.github/workflows/reusable-python-release_pypi_assets.yml
+++ b/.github/workflows/reusable-python-release_pypi_assets.yml
@@ -47,7 +47,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.tar.gz' -p '*.whl'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v2
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: download-assets

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           python-version: ${{inputs.python-version}}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3
         name: Setup conda env
         env:
           GIT_LFS_SKIP_SMUDGE: "1"
@@ -109,7 +109,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -119,14 +119,14 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
           cache-number: ${{ inputs.cache-number }}
           runner-os: ${{ runner.os }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.2
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:


### PR DESCRIPTION
**DEVOPS-1066 - use CI-tools v3 in all the repos**
follow-up of https://github.com/MiraGeoscience/CI-tools/pull/167: still need to change manually to @v3