### PR TITLE
[GEOPY-2769] Scope pylint modified-files run to pixi task cwd

### DIFF
--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -167,7 +167,14 @@ jobs:
             exit 1
           fi
           cwd=$(echo "$pixi_json" | jq -r --arg task "$PIXI_TASK" '.. | objects | select(.name == $task) | .cwd // empty' | head -1)
-          [ -n "$cwd" ] && echo "PIXI_TASK_CWD=$cwd" >> $GITHUB_ENV
+          if [ -n "$cwd" ]; then
+            delimiter="PIXI_TASK_CWD_EOF_$(date +%s%N)"
+            {
+              printf 'PIXI_TASK_CWD<<%s\n' "$delimiter"
+              printf '%s\n' "$cwd"
+              printf '%s\n' "$delimiter"
+            } >> "$GITHUB_ENV"
+          fi
 
       - name: Validate pixi task args
         if: ${{ inputs.package-manager == 'pixi' && inputs.pixi-task-args }}
@@ -192,7 +199,16 @@ jobs:
           elif ${{ inputs.package-manager == 'pixi' }}; then
             read -r -a files <<< "$FILES_PARAM"
             if [ -n "$PIXI_TASK_CWD" ]; then
-              readarray -t files < <(printf '%s\n' "${files[@]}" | grep "^${PIXI_TASK_CWD%/}/" | sed "s|^${PIXI_TASK_CWD%/}/||")
+              prefix="${PIXI_TASK_CWD%/}/"
+              filtered_files=()
+              for file in "${files[@]}"; do
+                case "$file" in
+                  "$prefix"*)
+                    filtered_files+=("${file#"$prefix"}")
+                    ;;
+                esac
+              done
+              files=("${filtered_files[@]}")
             fi
             if [ -n "$PIXI_TASK" ]; then
               if [ -n "$PIXI_TASK_ARGS" ]; then

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -167,14 +167,7 @@ jobs:
             exit 1
           fi
           task_cwd=$(echo "$pixi_json" | jq -r --arg task "$PIXI_TASK" '.. | objects | select(.name == $task) | .cwd // empty' | head -1)
-          if [ -n "$task_cwd" ]; then
-            delimiter="PIXI_TASK_CWD_EOF_$(date +%s%N)"
-            {
-              printf 'PIXI_TASK_CWD<<%s\n' "$delimiter"
-              printf '%s\n' "$task_cwd"
-              printf '%s\n' "$delimiter"
-            } >> "$GITHUB_ENV"
-          fi
+          [ -n "$task_cwd" ] && echo "PIXI_TASK_CWD=$task_cwd" >> $GITHUB_ENV
 
       - name: Validate pixi task args
         if: ${{ inputs.package-manager == 'pixi' && inputs.pixi-task-args }}

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -160,11 +160,14 @@ jobs:
         env:
           PIXI_TASK: ${{ inputs.pixi-task }}
         run: |
+          pixi_json=$(pixi task list --json)
           jq_filter='any(.. | objects; .name == $task and (has("cmd") or has("depends_on") or has("cwd") or has("clean_env")))'
-          if ! pixi task list --json | jq -e --arg task "$PIXI_TASK" "$jq_filter"; then
+          if ! echo "$pixi_json" | jq -e --arg task "$PIXI_TASK" "$jq_filter"; then
             echo "::error::Pixi task '$PIXI_TASK' is not defined in pixi.toml."
             exit 1
           fi
+          cwd=$(echo "$pixi_json" | jq -r --arg task "$PIXI_TASK" '.. | objects | select(.name == $task) | .cwd // empty' | head -1)
+          [ -n "$cwd" ] && echo "PIXI_TASK_CWD=$cwd" >> $GITHUB_ENV
 
       - name: Validate pixi task args
         if: ${{ inputs.package-manager == 'pixi' && inputs.pixi-task-args }}
@@ -188,6 +191,9 @@ jobs:
             poetry run pylint $FILES_PARAM
           elif ${{ inputs.package-manager == 'pixi' }}; then
             read -r -a files <<< "$FILES_PARAM"
+            if [ -n "$PIXI_TASK_CWD" ]; then
+              readarray -t files < <(printf '%s\n' "${files[@]}" | grep "^${PIXI_TASK_CWD%/}/" | sed "s|^${PIXI_TASK_CWD%/}/||")
+            fi
             if [ -n "$PIXI_TASK" ]; then
               if [ -n "$PIXI_TASK_ARGS" ]; then
                 readarray -t args < <(echo "$PIXI_TASK_ARGS" | jq -r '.[]')

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -166,12 +166,12 @@ jobs:
             echo "::error::Pixi task '$PIXI_TASK' is not defined in pixi.toml."
             exit 1
           fi
-          cwd=$(echo "$pixi_json" | jq -r --arg task "$PIXI_TASK" '.. | objects | select(.name == $task) | .cwd // empty' | head -1)
-          if [ -n "$cwd" ]; then
+          task_cwd=$(echo "$pixi_json" | jq -r --arg task "$PIXI_TASK" '.. | objects | select(.name == $task) | .cwd // empty' | head -1)
+          if [ -n "$task_cwd" ]; then
             delimiter="PIXI_TASK_CWD_EOF_$(date +%s%N)"
             {
               printf 'PIXI_TASK_CWD<<%s\n' "$delimiter"
-              printf '%s\n' "$cwd"
+              printf '%s\n' "$task_cwd"
               printf '%s\n' "$delimiter"
             } >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
**GEOPY-2769 - fix test with pixi in github for geopy-qa**
`PIXI_TASK_CWD` isn’t available during `git diff` because Pixi isn’t installed yet, so cwd filtering happens later. 

Parsing the `pixi.toml` could be an option earlier with Tomlib/tomli logic but would add extra complexity for little benefit.

Testing here: https://github.com/MiraGeoscience/geopy-qa/pull/21