### PR TITLE
DEVOPS-1060: [COPILOT Edit]: Add JIRA title trigger to PR workflow

### DIFF
--- a/.github/workflows/jira-pr_actions.yml
+++ b/.github/workflows/jira-pr_actions.yml
@@ -2,10 +2,11 @@ name: JIRA actions
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 jobs:
   call-workflow-pr_jira_actions:
+    if: github.event.action != 'edited' || github.event.changes.title != null
     uses: ./.github/workflows/reusable-jira-pr_actions.yml
     permissions:
       contents: read


### PR DESCRIPTION
**DEVOPS-1060 - in github, exception on jira number check for automatic PR Bumping CI-tools**
Add conditional to JIRA workflow to only trigger validation on PR title changes when the event is 'edited'.

Part of DEVOPS-1060: add-jira-title-trigger

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>