### PR TITLE
DEVOPS-1109: try updating rattler-build-action

### DIFF
--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -138,9 +138,8 @@ jobs:
                     cat < $RATTLER_AUTH_FILE
                     cat < ${{ runner.temp }}/credentials.json
             -   name: Build package
-                uses: prefix-dev/rattler-build-action@v0.2.34
+                uses: prefix-dev/rattler-build-action@v0.2.38
                 with:
-                    rattler-build-version: v0.34.1
                     build-args: >-
                         --output-dir ${{ runner.temp }}/output
                         --channel-priority strict


### PR DESCRIPTION
**DEVOPS-1109 - on GitHub, rattler fails to fetch packages dom artifactory**
Note: rattler-build-version is automatically pinned to the latest one
    available at the time the rattler-build-version action was released