### PR TITLE
DEVOPS-1120: CI-tools: use uv instead of plain pip for setuptools package

### DIFF
--- a/.github/workflows/reusable-python-build_poetry_package.yml
+++ b/.github/workflows/reusable-python-build_poetry_package.yml
@@ -16,10 +16,6 @@ on:
             description: Python version to use (e.g. 3.10)
             required: true
             type: string
-        version-tag:
-            description: Version tag of the package to build
-            required: true
-            type: string
         virtual-repo-names:
             description: 'List of repository names to resolve on (e.g. ["public-pypi-dev"])'
             required: true
@@ -41,9 +37,6 @@ on:
         build-dir-path:
             description: Path to the build directory
             value: ${{ jobs.build_package.outputs.build-dir-path }}
-        version:
-            description: Version of the package
-            value: ${{ jobs.build_package.outputs.version }}
     secrets:
         JFROG_ARTIFACTORY_URL:
             description: JFrog Artifactory URL
@@ -63,7 +56,6 @@ jobs:
         timeout-minutes: ${{ inputs.timeout-minutes }}
         outputs:
             build-dir-path: ${{ steps.define-build-path.outputs.dir-path }}
-            version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
                 uses: actions/checkout@v6
@@ -71,22 +63,6 @@ jobs:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
                     persist-credentials: false
-            -   name: Get version
-                id: get-version
-                env:
-                  INPUTS_VERSION_TAG: ${{ inputs.version-tag }}
-                run: |
-                    if [ "${INPUTS_VERSION_TAG}" = "v0.0.0" ]; then
-                        echo "Version tag not available"
-                        exit 1
-                    fi
-                    VERSION=$(echo "${INPUTS_VERSION_TAG}" | sed 's/v//')
-                    echo "version: ${VERSION}"
-                    if [ -z "${VERSION}" ]; then
-                        echo "Version is not available"
-                        exit 1
-                    fi
-                    echo "version=${VERSION}" >> $GITHUB_OUTPUT
             -   uses: jfrog/setup-jfrog-cli@v4.9.1
                 name: Setup JFrog CLI
                 env:

--- a/.github/workflows/reusable-python-build_setuptools_package.yml
+++ b/.github/workflows/reusable-python-build_setuptools_package.yml
@@ -70,6 +70,8 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ inputs.python-version }}
+            -   name: Setup uv
+                uses: astral-sh/setup-uv@v7
             -   name: Verify package installation
                 env:
                   INPUTS_VIRTUAL_REPO_NAMES: ${{ inputs.virtual-repo-names }}
@@ -79,9 +81,9 @@ jobs:
                         PIP_EXTRA_INDEX_URL="$PIP_EXTRA_INDEX_URL https://github:${{ secrets.JFROG_ARTIFACTORY_TOKEN }}@${{ secrets.JFROG_ARTIFACTORY_URL }}/artifactory/api/pypi/${repo_name}/simple"
                     done
                     export PIP_EXTRA_INDEX_URL
-                    pip install .
+                    uv pip install .
             -   name: Pip install build
-                run: pip install build
+                run: uv pip install build
             -   name: Build package
                 run: python -m build
             -   name: Define build path

--- a/.github/workflows/reusable-python-build_setuptools_package.yml
+++ b/.github/workflows/reusable-python-build_setuptools_package.yml
@@ -70,8 +70,6 @@ jobs:
                 uses: actions/setup-python@v6
                 with:
                     python-version: ${{ inputs.python-version }}
-            -   name: Setup uv
-                uses: astral-sh/setup-uv@v7
             -   name: Verify package installation
                 env:
                   INPUTS_VIRTUAL_REPO_NAMES: ${{ inputs.virtual-repo-names }}
@@ -81,9 +79,9 @@ jobs:
                         PIP_EXTRA_INDEX_URL="$PIP_EXTRA_INDEX_URL https://github:${{ secrets.JFROG_ARTIFACTORY_TOKEN }}@${{ secrets.JFROG_ARTIFACTORY_URL }}/artifactory/api/pypi/${repo_name}/simple"
                     done
                     export PIP_EXTRA_INDEX_URL
-                    uv pip install .
+                    pip install .
             -   name: Pip install build
-                run: uv pip install build
+                run: pip install build
             -   name: Build package
                 run: python -m build
             -   name: Define build path

--- a/.github/workflows/reusable-python-build_setuptools_package.yml
+++ b/.github/workflows/reusable-python-build_setuptools_package.yml
@@ -11,10 +11,6 @@ on:
             description: Python version to use (e.g. 3.10)
             required: true
             type: string
-        version-tag:
-            description: Version tag of the package to build
-            required: true
-            type: string
         virtual-repo-names:
             description: 'List of repository names to resolve on (e.g. ["public-pypi-dev"])'
             required: true
@@ -58,7 +54,6 @@ jobs:
         timeout-minutes: ${{ inputs.timeout-minutes }}
         outputs:
             build-dir-path: ${{ steps.define-build-path.outputs.dir-path }}
-            version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
                 uses: actions/checkout@v6
@@ -66,22 +61,6 @@ jobs:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
                     persist-credentials: false
-            -   name: Get version
-                id: get-version
-                env:
-                  INPUTS_VERSION_TAG: ${{ inputs.version-tag }}
-                run: |
-                    if [ "${INPUTS_VERSION_TAG}" = "v0.0.0" ]; then
-                        echo "Version tag not available"
-                        exit 1
-                    fi
-                    VERSION=$(echo "${INPUTS_VERSION_TAG}" | sed 's/v//')
-                    echo "version: ${VERSION}"
-                    if [ -z "${VERSION}" ]; then
-                        echo "Version is not available"
-                        exit 1
-                    fi
-                    echo "version=${VERSION}" >> $GITHUB_OUTPUT
             -   uses: jfrog/setup-jfrog-cli@v4.9.1
                 name: Setup JFrog CLI
                 env:

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -71,7 +71,7 @@ jobs:
     build_poetry_package:
         name: Build poetry package
         if: ${{ inputs.package-manager == 'poetry' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3.6.0-alpha.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3.7.0-alpha.1
         with:
             package-name: ${{ inputs.package-name }}
             source-path: ${{ inputs.source-path || '.' }}
@@ -87,7 +87,7 @@ jobs:
     build_setuptools_package:
         name: Build setuptools package
         if: ${{ inputs.package-manager == 'setuptools' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3.6.0-alpha.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3.7.0-alpha.1
         with:
             package-name: ${{ inputs.package-name }}
             python-version: ${{ inputs.python-version }}
@@ -101,7 +101,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.6.0-alpha.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.7.0-alpha.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -139,7 +139,7 @@ jobs:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ env.build-dir-path }}
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.6.0-alpha.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.7.0-alpha.1
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: ${{ env.build-dir-path }}
@@ -165,7 +165,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.6.0-alpha.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.7.0-alpha.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -72,7 +72,6 @@ jobs:
             source-path: ${{ inputs.source-path || '.' }}
             python-version: ${{ inputs.python-version }}
             lfs: ${{ inputs.lfs }}
-            version-tag: ${{ inputs.version-tag || github.ref_name }}
             virtual-repo-names: ${{ inputs.virtual-repo-names }}
             os: ${{ inputs.os }}
             timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -88,7 +87,6 @@ jobs:
             package-name: ${{ inputs.package-name }}
             python-version: ${{ inputs.python-version }}
             lfs: ${{ inputs.lfs }}
-            version-tag: ${{ inputs.version-tag || github.ref_name }}
             virtual-repo-names: ${{ inputs.virtual-repo-names }}
             os: ${{ inputs.os }}
             timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -112,16 +110,16 @@ jobs:
             fail-fast: false
             matrix:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
+        env:
+            VERSION_TAG: ${{ inputs.version-tag || github.ref_name }}
         steps:
             -   name: Select build outputs form the correct job
                 id: select-build-outputs
                 run: |
                     if [[ "${{ needs.build_poetry_package.result }}" == "success" ]]; then
                         echo "build-dir-path=${{ needs.build_poetry_package.outputs.build-dir-path }}" >> $GITHUB_ENV
-                        echo "version=${{ needs.build_poetry_package.outputs.version }}" >> $GITHUB_ENV
                     elif [[ "${{ needs.build_setuptools_package.result }}" == "success" ]]; then
                         echo "build-dir-path=${{ needs.build_setuptools_package.outputs.build-dir-path }}" >> $GITHUB_ENV
-                        echo "version=${{ needs.build_setuptools_package.outputs.version }}" >> $GITHUB_ENV
                     else
                         echo "No successful build found"
                         exit 1
@@ -136,7 +134,7 @@ jobs:
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: ${{ env.build-dir-path }}
-                    artifactory-dir-path: ${{ matrix.virtual-repo-name }}/${{ inputs.package-name }}/${{ env.version }}
+                    artifactory-dir-path: ${{ matrix.virtual-repo-name }}/${{ inputs.package-name }}/${{ env.VERSION_TAG }}
                     JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
                     JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
             -   name: Publish package to PyPI

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -44,6 +44,11 @@ on:
             description: Version tag of the package to build (defaults to github.ref_name if not provided)
             required: false
             type: string
+        publish-dev-tag:
+            description: Whether to publish a "dev" version of the package. By default a "dev" version tag is built but not published.
+            required: false
+            type: boolean
+            default: false
     secrets:
         JFROG_ARTIFACTORY_URL:
             description: JFrog Artifactory URL
@@ -103,7 +108,11 @@ jobs:
     publish_package:
         name: Publish package
         needs: [ build_poetry_package, build_setuptools_package, is_publishable ]
-        if: ${{ always() && contains(needs.*.result, 'success') && !contains(needs.*.result, 'failure') && github.repository_owner == 'MiraGeoscience' && needs.is_publishable.outputs.is-publishable == 'true' }}
+        if: |
+            always() &&
+            contains(needs.*.result, 'success') && !contains(needs.*.result, 'failure') &&
+            github.repository_owner == 'MiraGeoscience' &&
+            (needs.is_publishable.outputs.is-publishable == 'true' || inputs.publish-dev-tag)
         runs-on: ubuntu-latest
         timeout-minutes: 5
         strategy:

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -66,7 +66,7 @@ jobs:
     build_poetry_package:
         name: Build poetry package
         if: ${{ inputs.package-manager == 'poetry' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3.6.0-alpha.1
         with:
             package-name: ${{ inputs.package-name }}
             source-path: ${{ inputs.source-path || '.' }}
@@ -82,7 +82,7 @@ jobs:
     build_setuptools_package:
         name: Build setuptools package
         if: ${{ inputs.package-manager == 'setuptools' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3.6.0-alpha.1
         with:
             package-name: ${{ inputs.package-name }}
             python-version: ${{ inputs.python-version }}
@@ -96,7 +96,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.6.0-alpha.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -130,7 +130,7 @@ jobs:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ env.build-dir-path }}
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.6.0-alpha.1
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: ${{ env.build-dir-path }}
@@ -156,7 +156,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.6.0-alpha.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -55,6 +55,11 @@ on:
             description: Version tag of the package to build (defaults to github.ref_name if not provided)
             required: false
             type: string
+        publish-dev-tag:
+            description: Whether to publish a "dev" version of the package. By default a "dev" version tag is built but not published.
+            required: false
+            type: boolean
+            default: false
         build-experimental:
             description: Enable rattler-build experimental features
             required: false
@@ -160,7 +165,7 @@ jobs:
     publish_package:
         name: Publish package
         needs: [build_rattler_package, is_publishable]
-        if: ${{ github.repository_owner == 'MiraGeoscience' && needs.is_publishable.outputs.is-publishable == 'true' }}
+        if: ${{ github.repository_owner == 'MiraGeoscience' && (needs.is_publishable.outputs.is-publishable == 'true' || inputs.publish-dev-tag) }}
         runs-on: ubuntu-latest
         timeout-minutes: 5
         strategy:

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -158,7 +158,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.6.0-alpha.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.7.0-alpha.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -178,7 +178,7 @@ jobs:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: build-dir
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.6.0-alpha.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.7.0-alpha.1
                 with:
                     build-dir-path: build-dir/noarch
                     artifactory-dir-path: ${{ matrix.publish-repo-name}}/noarch
@@ -194,7 +194,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.6.0-alpha.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.7.0-alpha.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -153,7 +153,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.6.0-alpha.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -173,7 +173,7 @@ jobs:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: build-dir
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.6.0-alpha.1
                 with:
                     build-dir-path: build-dir/noarch
                     artifactory-dir-path: ${{ matrix.publish-repo-name}}/noarch
@@ -189,7 +189,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.6.0-alpha.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.6.0-alpha.1
         name: Setup conda env
         if: ${{ inputs.package-manager == 'conda' }}
         env:
@@ -127,7 +127,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.6.0-alpha.1
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -137,14 +137,14 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
           cache-number: ${{ inputs.cache-number }}
           runner-os: ${{ runner.os }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.6.0-alpha.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.7.0-alpha.1
         name: Setup conda env
         if: ${{ inputs.package-manager == 'conda' }}
         env:
@@ -127,7 +127,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.6.0-alpha.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.7.0-alpha.1
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           python-version: ${{inputs.python-version}}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3
         name: Setup conda env
         env:
           GIT_LFS_SKIP_SMUDGE: "1"
@@ -128,7 +128,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -138,14 +138,14 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
           cache-number: ${{ inputs.cache-number }}
           runner-os: ${{ runner.os }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.4.0
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:


### PR DESCRIPTION
**DEVOPS-1120 - CI-tools: use uv instead of plain pip for setuptools package**

changing scope: also introduce an option to publish dev version tags that would normally be built but not published
