### PR TITLE
DEVOPS-1137: Remove edited/title-change filter from JIRA PR actions workflow

### DIFF
--- a/.github/workflows/jira-pr_actions.yml
+++ b/.github/workflows/jira-pr_actions.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   call-workflow-pr_jira_actions:
-    if: github.event.action != 'edited' || github.event.changes.title != null
     uses: ./.github/workflows/reusable-jira-pr_actions.yml
     permissions:
       contents: read


### PR DESCRIPTION
**DEVOPS-1137 - In CI-tools fix bug for get_issue_key and check_jira_issue jobs**
Remove the `if: github.event.action != 'edited' || github.event.changes.title != null` condition from the JIRA PR actions job, so the reusable workflow runs on every triggering PR event instead of being skipped on non-title edits.

Part of DEVOPS-1137: remove-jira-pr-edited-filter

This PR was run by a PowerShell script with the help of Copilot.