### PR TITLE
DEVOPS-1133: Pin GitHub Actions to commit hashes

### DIFF
--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -30,7 +30,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v5.1.0
+    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       with:
         persist-credentials: false
     - name: Setup env vars
@@ -41,7 +41,7 @@ runs:
         echo "micromamba_version=2.1.0-0" >> "$GITHUB_ENV"
         echo "MAMBA_CHANNEL_ALIAS=https://repo.prefix.dev" >> "$GITHUB_ENV"
     - name: Setup micromamba
-      uses: mamba-org/setup-micromamba@v2.0.7
+      uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2.0.7
       with:
         micromamba-version: ${{ env.micromamba_version }}
         init-shell: bash
@@ -86,7 +86,7 @@ runs:
 
         echo "channels=$conda_channels" >> $GITHUB_OUTPUT
     - name: Create conda env
-      uses: mamba-org/setup-micromamba@v2.0.7
+      uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2.0.7
       with:
         micromamba-version: ${{ env.micromamba_version }}
         environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}

--- a/.github/actions/reusable-python-setup_conda/action.yml
+++ b/.github/actions/reusable-python-setup_conda/action.yml
@@ -30,7 +30,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v5.1.0
       with:
         persist-credentials: false
     - name: Setup env vars
@@ -41,7 +41,7 @@ runs:
         echo "micromamba_version=2.1.0-0" >> "$GITHUB_ENV"
         echo "MAMBA_CHANNEL_ALIAS=https://repo.prefix.dev" >> "$GITHUB_ENV"
     - name: Setup micromamba
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v2.0.7
       with:
         micromamba-version: ${{ env.micromamba_version }}
         init-shell: bash
@@ -86,7 +86,7 @@ runs:
 
         echo "channels=$conda_channels" >> $GITHUB_OUTPUT
     - name: Create conda env
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v2.0.7
       with:
         micromamba-version: ${{ env.micromamba_version }}
         environment-file: ${{ env.CONDA_LOCK_ENV_FILE }}

--- a/.github/actions/reusable-python-setup_hatch/action.yml
+++ b/.github/actions/reusable-python-setup_hatch/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
     - name: Set up cache
-      uses: actions/cache@v4
+      uses: actions/cache@v4.3.0
       id: cache
       with:
         path: ~/.cache/pip

--- a/.github/actions/reusable-python-setup_hatch/action.yml
+++ b/.github/actions/reusable-python-setup_hatch/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
     - name: Set up cache
-      uses: actions/cache@v4.3.0
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cache
       with:
         path: ~/.cache/pip

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
     - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
+      uses: snok/install-poetry@v1.4.2
       with:
         version: 2.1.3
         plugins: poetry-dynamic-versioning
@@ -50,7 +50,7 @@ runs:
           poetry config -- http-basic.${first_part} github ${INPUTS_JFROG_ARTIFACTORY_TOKEN}
         done
     - name: Set up cache
-      uses: actions/cache@v4
+      uses: actions/cache@v4.3.0
       id: cache
       with:
         path: .venv

--- a/.github/actions/reusable-python-setup_poetry/action.yml
+++ b/.github/actions/reusable-python-setup_poetry/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
     - name: Install and configure Poetry
-      uses: snok/install-poetry@v1.4.2
+      uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
       with:
         version: 2.1.3
         plugins: poetry-dynamic-versioning
@@ -50,7 +50,7 @@ runs:
           poetry config -- http-basic.${first_part} github ${INPUTS_JFROG_ARTIFACTORY_TOKEN}
         done
     - name: Set up cache
-      uses: actions/cache@v4.3.0
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cache
       with:
         path: .venv

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   call-workflow-dependabot-auto-merge:
-    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-dependabot-auto-merge.yml@DEVOPS-1061
+    uses: MiraGeoscience/CI-tools/.github/workflows/reusable-dependabot-auto-merge.yml@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/move-major-minor-tags.yml
+++ b/.github/workflows/move-major-minor-tags.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/move-major-minor-tags.yml
+++ b/.github/workflows/move-major-minor-tags.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-jira-issue_to_jira.yml
+++ b/.github/workflows/reusable-jira-issue_to_jira.yml
@@ -86,7 +86,7 @@ jobs:
         echo "Created JIRA issue: $issue_key"
         echo "issue=$issue_key" >> "$GITHUB_OUTPUT"
     - name: Post JIRA link
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@v5.0.0
       with:
         # The number of the issue or pull request in which to create a comment.
         issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/reusable-jira-issue_to_jira.yml
+++ b/.github/workflows/reusable-jira-issue_to_jira.yml
@@ -86,7 +86,7 @@ jobs:
         echo "Created JIRA issue: $issue_key"
         echo "issue=$issue_key" >> "$GITHUB_OUTPUT"
     - name: Post JIRA link
-      uses: peter-evans/create-or-update-comment@v5.0.0
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         # The number of the issue or pull request in which to create a comment.
         issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -53,7 +53,7 @@ jobs:
           depth=$(expr ${{ github.event.pull_request.commits }} + 1)
           echo "base-depth=$depth"
           echo "base-depth=$depth" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.1.0
         with:
           lfs: ${{ inputs.lfs }}
           # for non PR events, check out to depth 1 (the default)
@@ -69,15 +69,15 @@ jobs:
         run: |
           git config --local --unset-all http.https://github.com/.extraheader || [ $? -eq 5 ]
           git config --local --unset-all include.path || [ $? -eq 5 ]
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
       - name: Install pre-commit with uv
         run: uv tool install pre-commit
       - name: Cache for pre-commit hooks
-        uses: actions/cache@v5
+        uses: actions/cache@v5.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/reusable-pre_commit.yml
+++ b/.github/workflows/reusable-pre_commit.yml
@@ -53,7 +53,7 @@ jobs:
           depth=$(expr ${{ github.event.pull_request.commits }} + 1)
           echo "base-depth=$depth"
           echo "base-depth=$depth" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           lfs: ${{ inputs.lfs }}
           # for non PR events, check out to depth 1 (the default)
@@ -69,15 +69,15 @@ jobs:
         run: |
           git config --local --unset-all http.https://github.com/.extraheader || [ $? -eq 5 ]
           git config --local --unset-all include.path || [ $? -eq 5 ]
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Install pre-commit with uv
         run: uv tool install pre-commit
       - name: Cache for pre-commit hooks
-        uses: actions/cache@v5.1.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/reusable-python-build_poetry_package.yml
+++ b/.github/workflows/reusable-python-build_poetry_package.yml
@@ -66,7 +66,7 @@ jobs:
             version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6.1.0
+                uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
@@ -87,14 +87,14 @@ jobs:
                         exit 1
                     fi
                     echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            -   uses: jfrog/setup-jfrog-cli@v4.9.1
+            -   uses: jfrog/setup-jfrog-cli@279b1f629f43dd5bc658d8361ac4802a7ef8d2d5 # v4.9.1
                 name: Setup JFrog CLI
                 env:
                     JF_URL: https://${{ secrets.JFROG_ARTIFACTORY_URL }}
                     JF_ACCESS_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
             -   name: Set up Python version
-                uses: actions/setup-python@v6.3.0
+                uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
                 with:
                     python-version: ${{ inputs.python-version }}
             -   name: Install poetry
@@ -132,7 +132,7 @@ jobs:
                     fi
                     echo "dir-path=${DIR_PATH}" >> $GITHUB_OUTPUT
             -   name: Archive build artifact
-                uses: actions/upload-artifact@v7.0.1
+                uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ steps.define-build-path.outputs.dir-path }}

--- a/.github/workflows/reusable-python-build_poetry_package.yml
+++ b/.github/workflows/reusable-python-build_poetry_package.yml
@@ -66,7 +66,7 @@ jobs:
             version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6
+                uses: actions/checkout@v6.1.0
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
@@ -94,7 +94,7 @@ jobs:
                     JF_ACCESS_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
             -   name: Set up Python version
-                uses: actions/setup-python@v6
+                uses: actions/setup-python@v6.3.0
                 with:
                     python-version: ${{ inputs.python-version }}
             -   name: Install poetry
@@ -132,7 +132,7 @@ jobs:
                     fi
                     echo "dir-path=${DIR_PATH}" >> $GITHUB_OUTPUT
             -   name: Archive build artifact
-                uses: actions/upload-artifact@v7
+                uses: actions/upload-artifact@v7.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ steps.define-build-path.outputs.dir-path }}

--- a/.github/workflows/reusable-python-build_setuptools_package.yml
+++ b/.github/workflows/reusable-python-build_setuptools_package.yml
@@ -61,7 +61,7 @@ jobs:
             version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6
+                uses: actions/checkout@v6.1.0
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
@@ -88,7 +88,7 @@ jobs:
                     JF_URL: https://${{ secrets.JFROG_ARTIFACTORY_URL }}
                     JF_ACCESS_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
             -   name: Set up Python version
-                uses: actions/setup-python@v6
+                uses: actions/setup-python@v6.3.0
                 with:
                     python-version: ${{ inputs.python-version }}
             -   name: Verify package installation
@@ -116,7 +116,7 @@ jobs:
                     fi
                     echo "dir-path=${DIR_PATH}" >> $GITHUB_OUTPUT
             -   name: Archive build artifact
-                uses: actions/upload-artifact@v7
+                uses: actions/upload-artifact@v7.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ steps.define-build-path.outputs.dir-path }}

--- a/.github/workflows/reusable-python-build_setuptools_package.yml
+++ b/.github/workflows/reusable-python-build_setuptools_package.yml
@@ -61,7 +61,7 @@ jobs:
             version: ${{ steps.get-version.outputs.version }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6.1.0
+                uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
@@ -82,13 +82,13 @@ jobs:
                         exit 1
                     fi
                     echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            -   uses: jfrog/setup-jfrog-cli@v4.9.1
+            -   uses: jfrog/setup-jfrog-cli@279b1f629f43dd5bc658d8361ac4802a7ef8d2d5 # v4.9.1
                 name: Setup JFrog CLI
                 env:
                     JF_URL: https://${{ secrets.JFROG_ARTIFACTORY_URL }}
                     JF_ACCESS_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
             -   name: Set up Python version
-                uses: actions/setup-python@v6.3.0
+                uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
                 with:
                     python-version: ${{ inputs.python-version }}
             -   name: Verify package installation
@@ -116,7 +116,7 @@ jobs:
                     fi
                     echo "dir-path=${DIR_PATH}" >> $GITHUB_OUTPUT
             -   name: Archive build artifact
-                uses: actions/upload-artifact@v7.0.1
+                uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ steps.define-build-path.outputs.dir-path }}

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -66,7 +66,7 @@ jobs:
     build_poetry_package:
         name: Build poetry package
         if: ${{ inputs.package-manager == 'poetry' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3.9.1
         with:
             package-name: ${{ inputs.package-name }}
             source-path: ${{ inputs.source-path || '.' }}
@@ -83,7 +83,7 @@ jobs:
     build_setuptools_package:
         name: Build setuptools package
         if: ${{ inputs.package-manager == 'setuptools' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3.9.1
         with:
             package-name: ${{ inputs.package-name }}
             python-version: ${{ inputs.python-version }}
@@ -98,7 +98,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.9.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -127,12 +127,12 @@ jobs:
                         exit 1
                     fi
             -   name: Download build artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ env.build-dir-path }}
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: ${{ env.build-dir-path }}
@@ -158,12 +158,12 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   name: Download build artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: download-artifact

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -66,7 +66,7 @@ jobs:
     build_poetry_package:
         name: Build poetry package
         if: ${{ inputs.package-manager == 'poetry' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         with:
             package-name: ${{ inputs.package-name }}
             source-path: ${{ inputs.source-path || '.' }}
@@ -83,7 +83,7 @@ jobs:
     build_setuptools_package:
         name: Build setuptools package
         if: ${{ inputs.package-manager == 'setuptools' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         with:
             package-name: ${{ inputs.package-name }}
             python-version: ${{ inputs.python-version }}
@@ -98,7 +98,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -132,7 +132,7 @@ jobs:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ env.build-dir-path }}
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: ${{ env.build-dir-path }}
@@ -158,7 +158,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-publish_pypi_package.yml
+++ b/.github/workflows/reusable-python-publish_pypi_package.yml
@@ -66,7 +66,7 @@ jobs:
     build_poetry_package:
         name: Build poetry package
         if: ${{ inputs.package-manager == 'poetry' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         with:
             package-name: ${{ inputs.package-name }}
             source-path: ${{ inputs.source-path || '.' }}
@@ -83,7 +83,7 @@ jobs:
     build_setuptools_package:
         name: Build setuptools package
         if: ${{ inputs.package-manager == 'setuptools' && github.repository_owner == 'MiraGeoscience' }}
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         with:
             package-name: ${{ inputs.package-name }}
             python-version: ${{ inputs.python-version }}
@@ -98,7 +98,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -127,12 +127,12 @@ jobs:
                         exit 1
                     fi
             -   name: Download build artifact
-                uses: actions/download-artifact@v8.0.1
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: ${{ env.build-dir-path }}
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: ${{ env.build-dir-path }}
@@ -141,7 +141,7 @@ jobs:
                     JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
             -   name: Publish package to PyPI
                 if: ${{ matrix.virtual-repo-name == 'pypi'  || matrix.virtual-repo-name == 'test-pypi'}}
-                uses: pypa/gh-action-pypi-publish@release/v1
+                uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
                 with:
                     verbose: true
                     packages-dir: ${{ env.build-dir-path }}/
@@ -158,12 +158,12 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   name: Download build artifact
-                uses: actions/download-artifact@v8.0.1
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-pip-package-build
                     path: download-artifact

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -88,13 +88,13 @@ jobs:
             RECIPE_PATH: ${{ inputs.recipe-path || format('{0}/{1}', inputs.source-path || '.', 'recipe.yaml') }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6.1.0
+                uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
                     persist-credentials: false
             -   name: Set up Python version
-                uses: actions/setup-python@v6.3.0
+                uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
                 with:
                     python-version: ${{ inputs.python-version }}
             -   name: Generate package version
@@ -133,7 +133,7 @@ jobs:
 
                     echo "BUILD_ARGS=$BUILD_ARGS" >> "$GITHUB_OUTPUT"
             -   name: Build package
-                uses: prefix-dev/rattler-build-action@v0.2.38
+                uses: prefix-dev/rattler-build-action@ca874f064b8716c9da7cb420cf9affa13a5899d8 # v0.2.38
                 with:
                     upload-artifact: false  # upload happens at the next step with more options
                     build-args: >-
@@ -145,7 +145,7 @@ jobs:
                     RATTLER_AUTH_FILE: ${{ runner.temp }}/credentials.json
                     RATTLER_BUILD_EXPERIMENTAL: ${{ inputs.build-experimental && 'true' || 'false' }}
             -   name: Archive build artifact
-                uses: actions/upload-artifact@v7.0.1
+                uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
                 with:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: ${{ runner.temp }}/output/**/*.conda
@@ -153,7 +153,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -168,12 +168,12 @@ jobs:
                 publish-repo-name: ${{ fromJson(inputs.publish-repo-names) }}
         steps:
             -   name: Download build artifact
-                uses: actions/download-artifact@v8.0.1
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: build-dir
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 with:
                     build-dir-path: build-dir/noarch
                     artifactory-dir-path: ${{ matrix.publish-repo-name}}/noarch
@@ -189,12 +189,12 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   name: Download build artifact
-                uses: actions/download-artifact@v8.0.1
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: download-artifact

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -153,7 +153,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -173,7 +173,7 @@ jobs:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: build-dir
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 with:
                     build-dir-path: build-dir/noarch
                     artifactory-dir-path: ${{ matrix.publish-repo-name}}/noarch
@@ -189,7 +189,7 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-python-publish_rattler_package.yml
+++ b/.github/workflows/reusable-python-publish_rattler_package.yml
@@ -88,13 +88,13 @@ jobs:
             RECIPE_PATH: ${{ inputs.recipe-path || format('{0}/{1}', inputs.source-path || '.', 'recipe.yaml') }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v6
+                uses: actions/checkout@v6.1.0
                 with:
                     lfs: ${{ inputs.lfs }}
                     fetch-depth: 0
                     persist-credentials: false
             -   name: Set up Python version
-                uses: actions/setup-python@v6
+                uses: actions/setup-python@v6.3.0
                 with:
                     python-version: ${{ inputs.python-version }}
             -   name: Generate package version
@@ -145,7 +145,7 @@ jobs:
                     RATTLER_AUTH_FILE: ${{ runner.temp }}/credentials.json
                     RATTLER_BUILD_EXPERIMENTAL: ${{ inputs.build-experimental && 'true' || 'false' }}
             -   name: Archive build artifact
-                uses: actions/upload-artifact@v7
+                uses: actions/upload-artifact@v7.0.1
                 with:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: ${{ runner.temp }}/output/**/*.conda
@@ -153,7 +153,7 @@ jobs:
 
     is_publishable:
         name: Check version publishability
-        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3
+        uses: MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3.9.1
         with:
           version-tag: ${{ inputs.version-tag || github.ref_name }}
 
@@ -168,12 +168,12 @@ jobs:
                 publish-repo-name: ${{ fromJson(inputs.publish-repo-names) }}
         steps:
             -   name: Download build artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: build-dir
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
                 with:
                     build-dir-path: build-dir/noarch
                     artifactory-dir-path: ${{ matrix.publish-repo-name}}/noarch
@@ -189,12 +189,12 @@ jobs:
         timeout-minutes: 5
         steps:
             -   name: Get draft release
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
                 id: get-draft-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             -   name: Download build artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@v8.0.1
                 with:
                     name: ${{ inputs.package-name }}-conda-package-build
                     path: download-artifact

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -121,19 +121,19 @@ jobs:
         shell: 'bash -l {0}'
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           lfs: ${{ inputs.lfs }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python version
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         if: ${{ inputs.package-manager == 'poetry' || inputs.package-manager == 'hatch' }}
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup conda env
         if: ${{ inputs.package-manager == 'conda' }}
         env:
@@ -145,7 +145,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -155,7 +155,7 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
@@ -188,7 +188,7 @@ jobs:
         shell: bash
         run: gh auth setup-git
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:
@@ -239,7 +239,7 @@ jobs:
 
       - name: Codecov
         if: ${{ (inputs.codecov-reference-python-version) && (matrix.python-version == inputs.codecov-reference-python-version) && contains(inputs.codecov-reference-os, matrix.os) && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') }}
-        uses: codecov/codecov-action@v6.0.2
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           name: GitHub
           fail_ci_if_error: true

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup conda env
         if: ${{ inputs.package-manager == 'conda' }}
         env:
@@ -145,7 +145,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -155,7 +155,7 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
@@ -188,7 +188,7 @@ jobs:
         shell: bash
         run: gh auth setup-git
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:

--- a/.github/workflows/reusable-python-pytest.yml
+++ b/.github/workflows/reusable-python-pytest.yml
@@ -121,19 +121,19 @@ jobs:
         shell: 'bash -l {0}'
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.1.0
         with:
           lfs: ${{ inputs.lfs }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python version
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.3.0
         if: ${{ inputs.package-manager == 'poetry' || inputs.package-manager == 'hatch' }}
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.9.1
         name: Setup conda env
         if: ${{ inputs.package-manager == 'conda' }}
         env:
@@ -145,7 +145,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.9.1
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -155,7 +155,7 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3.9.1
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
@@ -188,7 +188,7 @@ jobs:
         shell: bash
         run: gh auth setup-git
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.9.1
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:
@@ -239,7 +239,7 @@ jobs:
 
       - name: Codecov
         if: ${{ (inputs.codecov-reference-python-version) && (matrix.python-version == inputs.codecov-reference-python-version) && contains(inputs.codecov-reference-os, matrix.os) && !(github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v6.0.2
         with:
           name: GitHub
           fail_ci_if_error: true

--- a/.github/workflows/reusable-python-release_conda_assets.yml
+++ b/.github/workflows/reusable-python-release_conda_assets.yml
@@ -39,7 +39,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.conda'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
                 with:
                     build-dir-path: download-assets
                     artifactory-dir-path: ${{ matrix.virtual-repo-name}}/noarch

--- a/.github/workflows/reusable-python-release_conda_assets.yml
+++ b/.github/workflows/reusable-python-release_conda_assets.yml
@@ -39,7 +39,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.conda'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 with:
                     build-dir-path: download-assets
                     artifactory-dir-path: ${{ matrix.virtual-repo-name}}/noarch

--- a/.github/workflows/reusable-python-release_conda_assets.yml
+++ b/.github/workflows/reusable-python-release_conda_assets.yml
@@ -39,7 +39,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.conda'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 with:
                     build-dir-path: download-assets
                     artifactory-dir-path: ${{ matrix.virtual-repo-name}}/noarch

--- a/.github/workflows/reusable-python-release_pypi_assets.yml
+++ b/.github/workflows/reusable-python-release_pypi_assets.yml
@@ -47,7 +47,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.tar.gz' -p '*.whl'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: download-assets

--- a/.github/workflows/reusable-python-release_pypi_assets.yml
+++ b/.github/workflows/reusable-python-release_pypi_assets.yml
@@ -47,7 +47,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.tar.gz' -p '*.whl'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: download-assets

--- a/.github/workflows/reusable-python-release_pypi_assets.yml
+++ b/.github/workflows/reusable-python-release_pypi_assets.yml
@@ -47,7 +47,7 @@ jobs:
                 virtual-repo-name: ${{ fromJson(inputs.virtual-repo-names) }}
         steps:
             -   name: Find release from tag
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 id: find-release
                 with:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
                     cd download-assets
                     gh release download ${INPUTS_RELEASE_TAG} -p '*.tar.gz' -p '*.whl'
             -   name: Publish package to Artifactory
-                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3.9.1
+                uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
                 if: ${{ matrix.virtual-repo-name != 'pypi' && matrix.virtual-repo-name != 'test-pypi' }}
                 with:
                     build-dir-path: download-assets
@@ -71,7 +71,7 @@ jobs:
                     JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
             -   name: Publish package to PyPI
                 if: ${{ matrix.virtual-repo-name == 'pypi'  || matrix.virtual-repo-name == 'test-pypi'}}
-                uses: pypa/gh-action-pypi-publish@release/v1
+                uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
                 with:
                     verbose: true
                     packages-dir: download-assets/

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -122,7 +122,7 @@ jobs:
         shell: 'bash -l {0}'
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.1.0
         with:
           lfs: ${{ inputs.lfs }}
           fetch-depth: 0
@@ -173,12 +173,12 @@ jobs:
           git config --local --unset-all include.path || [ $? -eq 5 ]
 
       - name: Set up Python version
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.3.0
         if: ${{ inputs.package-manager == 'poetry' || inputs.package-manager == 'hatch' }}
         with:
           python-version: ${{inputs.python-version}}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.9.1
         name: Setup conda env
         env:
           GIT_LFS_SKIP_SMUDGE: "1"
@@ -190,7 +190,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.9.1
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -200,7 +200,7 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3.9.1
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
@@ -233,7 +233,7 @@ jobs:
         shell: bash
         run: gh auth setup-git
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.9.1
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -178,7 +178,7 @@ jobs:
         with:
           python-version: ${{inputs.python-version}}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup conda env
         env:
           GIT_LFS_SKIP_SMUDGE: "1"
@@ -190,7 +190,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -200,7 +200,7 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
@@ -233,7 +233,7 @@ jobs:
         shell: bash
         run: gh auth setup-git
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:

--- a/.github/workflows/reusable-python-static_analysis.yml
+++ b/.github/workflows/reusable-python-static_analysis.yml
@@ -122,7 +122,7 @@ jobs:
         shell: 'bash -l {0}'
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
-      - uses: actions/checkout@v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           lfs: ${{ inputs.lfs }}
           fetch-depth: 0
@@ -173,12 +173,12 @@ jobs:
           git config --local --unset-all include.path || [ $? -eq 5 ]
 
       - name: Set up Python version
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         if: ${{ inputs.package-manager == 'poetry' || inputs.package-manager == 'hatch' }}
         with:
           python-version: ${{inputs.python-version}}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup conda env
         env:
           GIT_LFS_SKIP_SMUDGE: "1"
@@ -190,7 +190,7 @@ jobs:
           JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup poetry env
         if: ${{ inputs.package-manager == 'poetry' }}
         with:
@@ -200,7 +200,7 @@ jobs:
           virtual-repo-names: ${{ inputs.virtual-repo-names }}
           JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup hatch env
         if: ${{ inputs.package-manager == 'hatch' }}
         with:
@@ -233,7 +233,7 @@ jobs:
         shell: bash
         run: gh auth setup-git
 
-      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3.9.1
+      - uses: MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
         name: Setup pixi env
         if: ${{ inputs.package-manager == 'pixi' }}
         with:

--- a/.github/workflows/reusable-version-check.yml
+++ b/.github/workflows/reusable-version-check.yml
@@ -36,11 +36,11 @@ jobs:
           requires-python = ">=3.12"
           EOF
       - name: Setup Python
-        uses: actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7.6.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           working-directory: ${{ runner.temp }}/version-check

--- a/.github/workflows/reusable-version-check.yml
+++ b/.github/workflows/reusable-version-check.yml
@@ -36,11 +36,11 @@ jobs:
           requires-python = ">=3.12"
           EOF
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: '3.12'
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v7.6.0
         with:
           enable-cache: true
           working-directory: ${{ runner.temp }}/version-check

--- a/.github/workflows/reusable-zizmor-advanced-security.yml
+++ b/.github/workflows/reusable-zizmor-advanced-security.yml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3.9.1
 
       - name: Run Zizmor Security Scan
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d

--- a/.github/workflows/reusable-zizmor-advanced-security.yml
+++ b/.github/workflows/reusable-zizmor-advanced-security.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
 
       - name: Run Zizmor Security Scan
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # 0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d

--- a/.github/workflows/reusable-zizmor-advanced-security.yml
+++ b/.github/workflows/reusable-zizmor-advanced-security.yml
@@ -31,15 +31,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
 
       - name: Run Zizmor Security Scan
-        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # 0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d
         with:
           advanced-security: true
           annotations: false

--- a/.github/workflows/reusable-zizmor-annotate.yml
+++ b/.github/workflows/reusable-zizmor-annotate.yml
@@ -31,15 +31,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
 
       - name: Run Zizmor Security Scan
-        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # 0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d
         with:
           advanced-security: false
           annotations: true

--- a/.github/workflows/reusable-zizmor-annotate.yml
+++ b/.github/workflows/reusable-zizmor-annotate.yml
@@ -31,12 +31,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3.9.1
 
       - name: Run Zizmor Security Scan
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d

--- a/.github/workflows/reusable-zizmor-annotate.yml
+++ b/.github/workflows/reusable-zizmor-annotate.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
 
       - name: Run Zizmor Security Scan
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # 0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d

--- a/.github/workflows/reusable-zizmor-security.yml
+++ b/.github/workflows/reusable-zizmor-security.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@3ff92aeffa5b92d646abea073ed5ad06117e57f6 # v3.11.0
 
       - name: Run Zizmor Security Scan
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # 0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d

--- a/.github/workflows/reusable-zizmor-security.yml
+++ b/.github/workflows/reusable-zizmor-security.yml
@@ -30,15 +30,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3.9.1
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@89672b26b20a657bed31f84496961abc07166a95 # v3.9.1
 
       - name: Run Zizmor Security Scan
-        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # 0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d
         with:
           advanced-security: false
           annotations: false

--- a/.github/workflows/reusable-zizmor-security.yml
+++ b/.github/workflows/reusable-zizmor-security.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Zizmor Config
-        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3
+        uses: MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3.9.1
 
       - name: Run Zizmor Security Scan
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d


### PR DESCRIPTION
**DEVOPS-1133 - pin all GitHub actions and reusable workflows to hash**
Expands moving GitHub Actions tags to the full semver tag pointing at the same commit, then pins every `uses:` to a commit hash with a dependabot-readable version comment.

Tags expanded in this repo:

- `actions/checkout@v5 -> @v5.1.0`
- `mamba-org/setup-micromamba@v2 -> @v2.0.7`
- `mamba-org/setup-micromamba@v2 -> @v2.0.7`
- `actions/cache@v4 -> @v4.3.0`
- `snok/install-poetry@v1 -> @v1.4.2`
- `actions/cache@v4 -> @v4.3.0`
- `actions/checkout@v6 -> @v6.1.0`
- `peter-evans/create-or-update-comment@v5 -> @v5.0.0`
- `actions/checkout@v6 -> @v6.1.0`
- `actions/setup-python@v6 -> @v6.3.0`
- `astral-sh/setup-uv@v7 -> @v7.6.0`
- `actions/cache@v5 -> @v5.1.0`
- `actions/checkout@v6 -> @v6.1.0`
- `actions/setup-python@v6 -> @v6.3.0`
- `actions/upload-artifact@v7 -> @v7.0.1`
- `actions/checkout@v6 -> @v6.1.0`
- `actions/setup-python@v6 -> @v6.3.0`
- `actions/upload-artifact@v7 -> @v7.0.1`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_poetry_package.yml@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-python-build_setuptools_package.yml@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3 -> @v3.9.1`
- `actions/download-artifact@v8 -> @v8.0.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3 -> @v3.9.1`
- `actions/download-artifact@v8 -> @v8.0.1`
- `actions/checkout@v6 -> @v6.1.0`
- `actions/setup-python@v6 -> @v6.3.0`
- `actions/upload-artifact@v7 -> @v7.0.1`
- `MiraGeoscience/CI-tools/.github/workflows/reusable-version-check.yml@v3 -> @v3.9.1`
- `actions/download-artifact@v8 -> @v8.0.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3 -> @v3.9.1`
- `actions/download-artifact@v8 -> @v8.0.1`
- `actions/checkout@v6 -> @v6.1.0`
- `actions/setup-python@v6 -> @v6.3.0`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3 -> @v3.9.1`
- `codecov/codecov-action@v6 -> @v6.0.2`
- `MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-get_draft_release@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-publish_to_artifactory@v3 -> @v3.9.1`
- `actions/checkout@v6 -> @v6.1.0`
- `actions/setup-python@v6 -> @v6.3.0`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_conda@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_poetry@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_hatch@v3 -> @v3.9.1`
- `MiraGeoscience/CI-tools/.github/actions/reusable-python-setup_pixi@v3 -> @v3.9.1`
- `actions/setup-python@v6 -> @v6.3.0`
- `astral-sh/setup-uv@v7 -> @v7.6.0`
- `actions/checkout@v6 -> @v6.1.0`
- `MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3 -> @v3.9.1`
- `actions/checkout@v6 -> @v6.1.0`
- `MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3 -> @v3.9.1`
- `actions/checkout@v6 -> @v6.1.0`
- `MiraGeoscience/CI-tools/.github/actions/setup-zizmor-config@v3 -> @v3.9.1`